### PR TITLE
fix: replace bash -c with sh -c for Alpine compatibility (#22)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,12 +100,12 @@ seed: seed-auth seed-crm ## Run all seeds (auth first, then CRM)
 
 seed-auth: ## Seed the Auth service (creates default user)
 	@echo "$(CYAN)Seeding Auth service...$(RESET)"
-	docker compose run --rm evo-auth bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+	docker compose run --rm evo-auth sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 	@echo "$(GREEN)Auth service seeded.$(RESET)"
 
 seed-crm: ## Seed the CRM service (creates default inbox)
 	@echo "$(CYAN)Seeding CRM service...$(RESET)"
-	docker compose run --rm evo-crm bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+	docker compose run --rm evo-crm sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 	@echo "$(GREEN)CRM service seeded.$(RESET)"
 
 ## —— Shell Access —————————————————————————————————————————————————————————————

--- a/docker-compose.prod-test.yaml
+++ b/docker-compose.prod-test.yaml
@@ -67,7 +67,7 @@ services:
   # ---------------------------------------------------------------------------
   evo_auth:
     image: evoapicloud/evo-auth-service-community:latest
-    command: bash -c "bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
+    command: sh -c "bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
     ports:
       - "3001:3001"
     environment:
@@ -104,7 +104,7 @@ services:
 
   evo_auth_sidekiq:
     image: evoapicloud/evo-auth-service-community:latest
-    command: bash -c "bundle exec sidekiq"
+    command: sh -c "bundle exec sidekiq"
     environment:
       RAILS_ENV: production
       SECRET_KEY_BASE: "a]i9F#k2$$Lm7Nq0R!sT4uW6xZ8bD1eG3hJ5oP7rV9yAcE2fH4jM6pS8vX0zB3dK5nQ7tU9wY1"
@@ -128,7 +128,7 @@ services:
   # ---------------------------------------------------------------------------
   evo_crm:
     image: evoapicloud/evo-ai-crm-community:latest
-    command: bash -c "bundle exec rails db:prepare && bundle exec rails s -p 3000 -b 0.0.0.0"
+    command: sh -c "bundle exec rails db:prepare && bundle exec rails s -p 3000 -b 0.0.0.0"
     ports:
       - "3000:3000"
     environment:

--- a/docker-compose.swarm.yaml
+++ b/docker-compose.swarm.yaml
@@ -54,7 +54,7 @@ services:
   # ---------------------------------------------------------------------------
   evo_auth:
     image: evoapicloud/evo-auth-service-community:latest
-    command: bash -c "bundle exec rails db:migrate 2>&1 || echo 'Migration had errors, continuing...'; bundle exec rails s -p 3001 -b 0.0.0.0"
+    command: sh -c "bundle exec rails db:migrate 2>&1 || echo 'Migration had errors, continuing...'; bundle exec rails s -p 3001 -b 0.0.0.0"
     environment:
       RAILS_ENV: production
       RAILS_MAX_THREADS: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: bash -c "bundle install && bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
+    command: sh -c "bundle install && bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
       interval: 30s
@@ -84,7 +84,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: bash -c "bundle install && bundle exec sidekiq"
+    command: sh -c "bundle install && bundle exec sidekiq"
 
   # ---------------------------------------------------------------------------
   # CRM Service (Ruby / Rails) — Port 3000

--- a/setup.sh
+++ b/setup.sh
@@ -197,7 +197,7 @@ echo ""
 # Step 6: Seed Auth service (must be first)
 # ---------------------------------------------------------------------------
 info "Seeding Auth service (creating default account and user)..."
-docker compose run --rm evo-auth bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+docker compose run --rm evo-auth sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 success "Auth service seeded"
 
 echo ""
@@ -206,7 +206,7 @@ echo ""
 # Step 7: Seed CRM service
 # ---------------------------------------------------------------------------
 info "Seeding CRM service (creating default inbox)..."
-docker compose run --rm evo-crm bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+docker compose run --rm evo-crm sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 success "CRM service seeded"
 
 echo ""


### PR DESCRIPTION
<h2>Summary</h2>
<p>The Docker images for <code>evo-auth</code> and <code>evo-crm</code> services are built on <strong>Alpine Linux</strong> (<code>ruby:3.4.4-alpine3.21</code>), which does not ship with <code>bash</code>. Using <code>bash -c "..."</code> in container commands fails at runtime with:</p>

<pre><code>docker/entrypoints/rails.sh: exec: line 34: bash: not found
exit code 127</code></pre>

<p>The <code>rails.sh</code> entrypoint ends with <code>exec "$@"</code>, which tries to execute the command passed via docker-compose <code>command:</code>. When that command starts with <code>bash</code>, the exec fails because bash is not installed in the Alpine image.</p>

<p>All affected commands are simple <code>&amp;&amp;</code> chains fully compatible with POSIX <code>sh</code>, so the fix is a straight swap of <code>bash -c</code> for <code>sh -c</code>.</p>

<h2>Files Changed</h2>
<table>
  <thead>
    <tr><th>File</th><th>Changes</th></tr>
  </thead>
  <tbody>
    <tr><td><code>docker-compose.yml</code></td><td>evo-auth, evo-auth-sidekiq commands</td></tr>
    <tr><td><code>docker-compose.prod-test.yaml</code></td><td>evo_auth, evo_auth_sidekiq, evo_crm commands</td></tr>
    <tr><td><code>docker-compose.swarm.yaml</code></td><td>evo_auth command</td></tr>
    <tr><td><code>setup.sh</code></td><td>db seed commands for evo-auth and evo-crm</td></tr>
    <tr><td><code>Makefile</code></td><td>seed-auth and seed-crm targets</td></tr>
  </tbody>
</table>

<h2>Root Cause</h2>
<ol>
  <li>Dockerfile uses <code>FROM ruby:3.4.4-alpine3.21</code> &mdash; Alpine ships <code>/bin/sh</code> (BusyBox), not <code>/bin/bash</code></li>
  <li>docker-compose files pass <code>bash -c "..."</code> as the container command</li>
  <li><code>docker/entrypoints/rails.sh</code> line 34 runs <code>exec "$@"</code> which expands to <code>exec bash -c "..."</code></li>
  <li><code>bash</code> binary doesn't exist in the container &rarr; <strong>exit code 127</strong></li>
</ol>

<h2>Fixes</h2>
<p>Closes <a href="https://github.com/EvolutionAPI/evo-crm-community/issues/22">#22</a></p>

<h2>Test Plan</h2>
<ul>
  <li><input type="checkbox" disabled> <code>make setup</code> completes successfully without <code>bash: not found</code> errors</li>
  <li><input type="checkbox" disabled> <code>make seed-auth</code> runs and seeds the Auth service</li>
  <li><input type="checkbox" disabled> <code>make seed-crm</code> runs and seeds the CRM service</li>
  <li><input type="checkbox" disabled> <code>docker compose up</code> starts evo-auth and evo-auth-sidekiq correctly</li>
  <li><input type="checkbox" disabled> <code>docker compose -f docker-compose.prod-test.yaml up</code> still works</li>
  <li><input type="checkbox" disabled> All commands execute identically under <code>sh</code> (all are POSIX-compatible <code>&amp;&amp;</code>/<code>||</code>/<code>;</code> chains)</li>
</ul>
