### PR TITLE
fix: replace bash -c with sh -c for Alpine compatibility (#22)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,12 +100,12 @@ seed: seed-auth seed-crm ## Run all seeds (auth first, then CRM)
 
 seed-auth: ## Seed the Auth service (creates default user)
 	@echo "$(CYAN)Seeding Auth service...$(RESET)"
-	docker compose run --rm evo-auth bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+	docker compose run --rm evo-auth sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 	@echo "$(GREEN)Auth service seeded.$(RESET)"
 
 seed-crm: ## Seed the CRM service (creates default inbox)
 	@echo "$(CYAN)Seeding CRM service...$(RESET)"
-	docker compose run --rm evo-crm bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+	docker compose run --rm evo-crm sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 	@echo "$(GREEN)CRM service seeded.$(RESET)"
 
 ## —— Shell Access —————————————————————————————————————————————————————————————

--- a/docker-compose.prod-test.yaml
+++ b/docker-compose.prod-test.yaml
@@ -67,7 +67,7 @@ services:
   # ---------------------------------------------------------------------------
   evo_auth:
     image: evoapicloud/evo-auth-service-community:latest
-    command: bash -c "bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
+    command: sh -c "bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
     ports:
       - "3001:3001"
     environment:
@@ -104,7 +104,7 @@ services:
 
   evo_auth_sidekiq:
     image: evoapicloud/evo-auth-service-community:latest
-    command: bash -c "bundle exec sidekiq"
+    command: sh -c "bundle exec sidekiq"
     environment:
       RAILS_ENV: production
       SECRET_KEY_BASE: "a]i9F#k2$$Lm7Nq0R!sT4uW6xZ8bD1eG3hJ5oP7rV9yAcE2fH4jM6pS8vX0zB3dK5nQ7tU9wY1"
@@ -128,7 +128,7 @@ services:
   # ---------------------------------------------------------------------------
   evo_crm:
     image: evoapicloud/evo-ai-crm-community:latest
-    command: bash -c "bundle exec rails db:prepare && bundle exec rails s -p 3000 -b 0.0.0.0"
+    command: sh -c "bundle exec rails db:prepare && bundle exec rails s -p 3000 -b 0.0.0.0"
     ports:
       - "3000:3000"
     environment:

--- a/docker-compose.swarm.yaml
+++ b/docker-compose.swarm.yaml
@@ -66,7 +66,7 @@ services:
   # ---------------------------------------------------------------------------
   evo_auth:
     image: evoapicloud/evo-auth-service-community:latest
-    command: bash -c "bundle exec rails db:migrate 2>&1 || echo 'Migration had errors, continuing...'; bundle exec rails s -p 3001 -b 0.0.0.0"
+    command: sh -c "bundle exec rails db:migrate 2>&1 || echo 'Migration had errors, continuing...'; bundle exec rails s -p 3001 -b 0.0.0.0"
     environment:
       RAILS_ENV: production
       RAILS_MAX_THREADS: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: bash -c "bundle install && bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
+    command: sh -c "bundle install && bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
       interval: 30s
@@ -84,7 +84,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: bash -c "bundle install && bundle exec sidekiq"
+    command: sh -c "bundle install && bundle exec sidekiq"
 
   # ---------------------------------------------------------------------------
   # CRM Service (Ruby / Rails) — Port 3000

--- a/setup.sh
+++ b/setup.sh
@@ -197,7 +197,7 @@ echo ""
 # Step 6: Seed Auth service (must be first)
 # ---------------------------------------------------------------------------
 info "Seeding Auth service (creating default account and user)..."
-docker compose run --rm evo-auth bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+docker compose run --rm evo-auth sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 success "Auth service seeded"
 
 echo ""
@@ -206,7 +206,7 @@ echo ""
 # Step 7: Seed CRM service
 # ---------------------------------------------------------------------------
 info "Seeding CRM service (creating default inbox)..."
-docker compose run --rm evo-crm bash -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+docker compose run --rm evo-crm sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
 success "CRM service seeded"
 
 echo ""


### PR DESCRIPTION
## Summary

Clean cherry-pick of @NeritonDias's fix from #25. Original PR was opened from an outdated base, which made it drag 28 unrelated commits and 400+ conflicting files — this branch contains **only** the actual fix, rebased on top of current `develop`.

Closes #22.
Supersedes #25 (credit to @NeritonDias — commit authorship preserved).

## Problem

The Docker images for `evo-auth` and `evo-crm` services are built on **Alpine Linux** (`ruby:3.4.4-alpine3.21`), which does not ship with `bash`. Using `bash -c "..."` in container commands fails at runtime with:

```
docker/entrypoints/rails.sh: exec: line 34: bash: not found
exit code 127
```

The `rails.sh` entrypoint ends with `exec "$@"`, which tries to execute the command passed via docker-compose `command:`. When that command starts with `bash`, the exec fails because `bash` is not installed in the Alpine image.

## Fix

All affected commands are simple `&&` chains fully compatible with POSIX `sh`, so the fix is a straight swap of `bash -c` for `sh -c`.

| File | Changes |
|------|---------|
| `Makefile` | seed-auth, seed-crm targets |
| `docker-compose.yml` | evo-auth, evo-auth-sidekiq commands |
| `docker-compose.prod-test.yaml` | evo_auth, evo_auth_sidekiq, evo_crm commands |
| `docker-compose.swarm.yaml` | evo_auth command |
| `setup.sh` | db seed commands for evo-auth and evo-crm |

10 insertions, 10 deletions across 5 files.

## Test Plan

- [x] `bash -c` no longer present in any of the affected files (`rtk grep "bash -c"` → 0 hits in these files)
- [ ] `make setup` completes successfully without `bash: not found`
- [ ] `make seed-auth` / `make seed-crm` run under `sh`
- [ ] `docker compose up` starts evo-auth / evo-auth-sidekiq / evo-crm correctly
- [ ] `docker compose -f docker-compose.prod-test.yaml up` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace container and seeding commands to use POSIX sh instead of bash for services running on Alpine-based images.

Bug Fixes:
- Ensure evo-auth, evo-auth-sidekiq, and evo-crm containers start correctly on Alpine images by using sh -c in docker compose commands instead of bash -c.
- Fix make and setup seeding commands for Auth and CRM services to run under sh so they no longer fail when bash is unavailable on the container images.