### PR TITLE
ci: run validate-compose and lint-dockerfiles on PRs to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   validate-compose:


### PR DESCRIPTION
## Summary

- Add `develop` to the `pull_request.branches` filter in `.github/workflows/ci.yml`.
- Validate `docker-compose.yml` and lint all 5 Dockerfiles on every PR targeting `develop`, not only `main`.

## Motivation

Today, PRs to `develop` bypass CI entirely. This let the last few PRs merge into develop without any compose validation or hadolint checks. Since develop is the staging integration branch, broken compose or Dockerfiles compound and only surface at the `develop → main` merge — exactly when they are most expensive to fix.

## Test plan

- [ ] Merge this PR → open a new PR against develop → confirm `validate-compose` and `lint-dockerfiles` jobs run.
- [ ] Open a PR against main → jobs still run (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Extend the GitHub Actions pull_request trigger to include the develop branch in addition to main so CI runs on both.