### PR TITLE
fix(env): enforce non-localhost BACKEND_URL/FRONTEND_URL in production (EVO-985)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,12 @@ SIDEKIQ_CONCURRENCY=10
 # =============================================================================
 # CRM SERVICE (evo-ai-crm-community) — Port 3000
 # =============================================================================
+# BACKEND_URL — public URL the CRM uses to build webhook callbacks and other
+# absolute URLs sent to external integrations. MUST be overridden in production
+# with the real backend hostname (e.g. https://crm.example.com). The localhost
+# default below exists for local development only — leaving it unchanged in
+# production results in webhook URLs that point to localhost and silently break
+# integrations.
 BACKEND_URL=http://localhost:3000
 EVO_AI_CORE_SERVICE_URL=http://evo-core:5555
 EVO_AUTH_SERVICE_URL=http://evo-auth:3001

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,12 @@ EVOAI_CRM_API_TOKEN=6e10e689-58ce-4416-bf0d-f5818bf2dcf8
 # =============================================================================
 RAILS_ENV=development
 RAILS_MAX_THREADS=5
+# FRONTEND_URL - public URL of the CRM frontend. Used by the auth service for
+# OAuth redirects and as a webhook fallback in some channel adapters. MUST be
+# overridden in production with the real frontend hostname (e.g.
+# https://app.example.com). The localhost default below is for local development
+# only - leaving it unchanged in production results in broken redirects and
+# webhook URLs.
 FRONTEND_URL=http://localhost:5173
 
 # Doorkeeper JWT (OAuth2 tokens)
@@ -77,12 +83,12 @@ SIDEKIQ_CONCURRENCY=10
 # =============================================================================
 # CRM SERVICE (evo-ai-crm-community) — Port 3000
 # =============================================================================
-# BACKEND_URL — public URL the CRM uses to build webhook callbacks and other
+# BACKEND_URL - public URL the CRM uses to build webhook callbacks and other
 # absolute URLs sent to external integrations. MUST be overridden in production
 # with the real backend hostname (e.g. https://crm.example.com). The localhost
-# default below exists for local development only — leaving it unchanged in
-# production results in webhook URLs that point to localhost and silently break
-# integrations.
+# default below exists for local development only - leaving it unchanged in
+# production now causes the CRM to refuse to boot (config/environments/production.rb
+# raises if BACKEND_URL is missing or points at localhost).
 BACKEND_URL=http://localhost:3000
 EVO_AI_CORE_SERVICE_URL=http://evo-core:5555
 EVO_AUTH_SERVICE_URL=http://evo-auth:3001

--- a/README.md
+++ b/README.md
@@ -91,9 +91,16 @@ Refer to each service's own README for environment configuration, setup and seed
 - [evo-ai-core-service-community](https://github.com/EvolutionAPI/evo-ai-core-service-community#readme)
 - [evo-bot-runtime](https://github.com/EvolutionAPI/evo-bot-runtime#readme)
 
-> **Note:** `evo-auth-service-community` must be seeded before `evo-ai-crm-community` — the CRM depends on the user created by the auth seed.
+> **Note:** `evo-auth-service-community` must be seeded before `evo-ai-crm-community` - the CRM depends on the user created by the auth seed.
 
-> **Production note:** When deploying to a real environment, `BACKEND_URL` in `.env.example` must be overridden with the public URL of your CRM backend (e.g. `https://crm.example.com`). The bundled `http://localhost:3000` default exists for local development only and will produce broken webhook URLs in external integrations if left unchanged in production.
+> **Production deployment - required environment overrides**
+>
+> Before promoting any environment to production, the following variables in `.env.example` must be replaced with public URLs (the bundled `http://localhost:*` defaults exist for local development only):
+>
+> - **`BACKEND_URL`** - public URL of the CRM backend (e.g. `https://crm.example.com`). The CRM refuses to boot in production if this is missing or points at localhost.
+> - **`FRONTEND_URL`** - public URL of the frontend (e.g. `https://app.example.com`). Used for OAuth redirects and channel webhook fallbacks.
+>
+> Leaving the localhost defaults in production results in webhook callbacks pointing at the container, broken OAuth redirects and silently failed external integrations.
 
 For detailed setup instructions, visit the [full documentation](https://docs.evolutionfoundation.com.br).
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Refer to each service's own README for environment configuration, setup and seed
 
 > **Note:** `evo-auth-service-community` must be seeded before `evo-ai-crm-community` — the CRM depends on the user created by the auth seed.
 
+> **Production note:** When deploying to a real environment, `BACKEND_URL` in `.env.example` must be overridden with the public URL of your CRM backend (e.g. `https://crm.example.com`). The bundled `http://localhost:3000` default exists for local development only and will produce broken webhook URLs in external integrations if left unchanged in production.
+
 For detailed setup instructions, visit the [full documentation](https://docs.evolutionfoundation.com.br).
 
 ---

--- a/docker-compose.prod-test.yaml
+++ b/docker-compose.prod-test.yaml
@@ -1,13 +1,20 @@
 version: "3.8"
 
 # =============================================================================
-# Evo CRM Community — Local Production Test
+# Evo CRM Community - Local Production Test
 # =============================================================================
 # Simulates the production swarm stack locally using docker compose.
 # Uses the same Docker Hub images that would run in production.
 #
+# RAILS_ENV is set to production, so BACKEND_URL and FRONTEND_URL must be
+# non-localhost values (the CRM refuses to boot in production with localhost).
+# On Mac/Windows: host.docker.internal works out of the box.
+# On Linux: use the host LAN IP or add extra_hosts mapping.
+#
 # Usage:
-#   docker compose -f docker-compose.prod-test.yaml up -d
+#   BACKEND_URL=http://host.docker.internal:3030 \
+#   FRONTEND_URL=http://host.docker.internal:5173 \
+#     docker compose -f docker-compose.prod-test.yaml up -d
 #   docker compose -f docker-compose.prod-test.yaml logs -f
 #   docker compose -f docker-compose.prod-test.yaml down -v
 # =============================================================================
@@ -82,7 +89,7 @@ services:
       POSTGRES_PASSWORD: evoai_dev_password
       POSTGRES_DATABASE: evo_community
       REDIS_URL: redis://:evoai_redis_pass@evo_redis:6379/1
-      FRONTEND_URL: http://localhost:5173
+      FRONTEND_URL: "${FRONTEND_URL:?FRONTEND_URL must be set to a non-localhost URL for prod-test (e.g. http://host.docker.internal:5173)}"
       MAILER_SENDER_EMAIL: noreply@evoai.local
       DOORKEEPER_JWT_SECRET_KEY: "a]i9F#k2$$Lm7Nq0R!sT4uW6xZ8bD1eG3hJ5oP7rV9yAcE2fH4jM6pS8vX0zB3dK5nQ7tU9wY1"
       DOORKEEPER_JWT_ALGORITHM: hs256
@@ -146,9 +153,11 @@ services:
       REDIS_URL: redis://:evoai_redis_pass@evo_redis:6379/0
       EVO_AUTH_SERVICE_URL: http://evo_auth:3001
       EVO_AI_CORE_SERVICE_URL: http://evo_core:5555
-      BACKEND_URL: http://localhost:3030
-      FRONTEND_URL: http://localhost:5173
-      CORS_ORIGINS: http://localhost:5173,http://localhost:3030
+      BACKEND_URL: "${BACKEND_URL:?BACKEND_URL must be set to a non-localhost URL for prod-test (e.g. http://host.docker.internal:3030)}"
+      FRONTEND_URL: "${FRONTEND_URL:?FRONTEND_URL must be set to a non-localhost URL for prod-test (e.g. http://host.docker.internal:5173)}"
+      # CORS origins are the browser's Origin header (Vite serves on localhost:5173 from the host machine);
+      # they are independent of BACKEND_URL/FRONTEND_URL which are CRM-side URLs.
+      CORS_ORIGINS: "${CORS_ORIGINS:-http://localhost:5173,http://localhost:3030}"
       DISABLE_TELEMETRY: "true"
       LOG_LEVEL: info
       ENABLE_ACCOUNT_SIGNUP: "true"


### PR DESCRIPTION
## Summary

Address Davidson's adversarial review on EVO-985: documenting the localhost defaults was not enough on its own. The CRM now refuses to boot in production with a localhost `BACKEND_URL` (enforced in the submodule), and the docker-compose prod-test stack no longer hard-codes localhost values that contradicted the production runtime.

- `docker-compose.prod-test.yaml`: replace `BACKEND_URL`/`FRONTEND_URL` localhost hardcodes with mandatory `${VAR:?...}` substitutions (compose now fails fast with a clear error if the operator forgets to set them); keep `CORS_ORIGINS` pointed at the browser-side localhost origins because Vite serves on the host machine.
- `.env.example`: add the same warning block to `FRONTEND_URL` (medium-severity item from review, same class of bug); normalize ASCII dashes throughout the warning block; update the `BACKEND_URL` note to mention that production now raises rather than silently using the default.
- `README.md`: promote the production note to a more prominent callout block covering both `BACKEND_URL` and `FRONTEND_URL`, placed right next to the seeding note in the "Setup each service" section.

## Validation

- `cp .env.example .env && docker compose config --quiet` (mirrors CI's `Validate Docker Compose` job): exit 0
- `BACKEND_URL=http://host.docker.internal:3030 FRONTEND_URL=http://host.docker.internal:5173 docker compose -f docker-compose.prod-test.yaml config --quiet`: exit 0
- `docker compose -f docker-compose.prod-test.yaml config --quiet` (without env vars): exit 1 with explicit error "BACKEND_URL must be set to a non-localhost URL for prod-test (e.g. http://host.docker.internal:3030)"
- Boot tests of the submodule: `RAILS_ENV=production rails runner` raises as expected for missing/localhost values; passes for valid public URLs.

## Changed Files

- `.env.example`
- `README.md`
- `docker-compose.prod-test.yaml`

## Linked Issue

- Linear: [EVO-985](https://linear.app/evoai/issue/EVO-985/backend-url-default-in-envexample-points-to-localhost-breaks-webhook)
- Closes: EvolutionAPI/evo-crm-community#28

## Related PRs

- Submodule changes (`evo-ai-crm-community`): https://github.com/EvolutionAPI/evo-ai-crm-community/pull/30