### PR TITLE
fix(migrations): ensure cross‑service migrations on shared DB (replace `db:prepare` with `db:create && db:migrate`)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: bash -c "rm -f /rails/tmp/pids/server.pid && bundle install && bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
+    command: bash -c "rm -f /rails/tmp/pids/server.pid && bundle install && bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails s -p 3001 -b 0.0.0.0"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
       interval: 30s

--- a/setup.sh
+++ b/setup.sh
@@ -197,7 +197,7 @@ echo ""
 # Step 6: Seed Auth service (must be first)
 # ---------------------------------------------------------------------------
 info "Seeding Auth service (creating default account and user)..."
-docker compose run --rm evo-auth sh -c "bundle exec rails db:prepare && bundle exec rails db:seed"
+docker compose run --rm evo-auth sh -c "bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails db:seed"
 success "Auth service seeded"
 
 echo ""


### PR DESCRIPTION
## Summary
- Replace `rails db:prepare` with explicit `rails db:create && rails db:migrate` to make startup migrations reliable when multiple Rails services (CRM core and Auth) share the same PostgreSQL database.
- Apply the change in `docker-compose.yml` (CRM service startup) and in the auth seeding path (setup script), so each service runs its own migrations deterministically.
- Outcome: fewer race conditions and "partially prepared" states when bringing the stack up from scratch or after container recreation.

## Root cause
- Both evo‑crm (core) and evo‑auth have their own migration trees but point to the same database.
- `rails db:prepare` switches behavior depending on DB state (create + load schema vs migrate), and is more brittle in dev/compose setups (DB may not exist yet, or initial connection may flap).
- This led to scenarios where tables existed but one service’s migrations were not actually executed, leaving the system in an inconsistent state.

## Changes

### docker-compose.yml (CRM service)
- Startup command:
  - Before: `bundle exec rails db:prepare`
  - After: `bundle exec rails db:create && bundle exec rails db:migrate`

### setup.sh (Auth seeding path)
- Seeding flow:
  - Before: `bundle exec rails db:prepare && bundle exec rails db:seed`
  - After: `bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails db:seed`

## How it works
- `db:create` is idempotent in practice for compose/dev: it creates the database if missing; if it already exists, Rails prints a notice and continues.
- `db:migrate` then runs all pending migrations for the service that is starting (CRM or Auth). Since each service owns its own migration set, this ensures both sets are applied to the shared DB.
- This sequence is more explicit and resilient than `db:prepare` in multi‑service development environments.

## Test checklist
1) Clean slate
```bash
docker compose down -v
```
2) Bring the stack up
```bash
docker compose up -d
```
3) Services are healthy
```bash
docker compose ps
```
4) CRM migrations ran
```bash
docker compose exec evo-crm bundle exec rails db:migrate:status
```
5) Auth seeding/migrations ran
```bash
docker compose exec evo-auth bundle exec rails db:seed:status
```

## Backward compatibility
- No schema changes introduced by this PR; only startup commands.
- Safe for repeated runs. If DB exists and is up‑to‑date, `db:create` no‑ops and `db:migrate` exits cleanly.

## Known limitations
- This PR focuses on backend startup reliability. A related improvement for the frontend dev environment (nginx CSP must allow localhost:* during development) will be submitted as a separate PR.

## Related issues
- Relates-to #78 — “[Bug]: SEED CRM Failed” (fails with db:prepare + seed; this PR improves startup migration reliability across services on shared DB) & #69 

## Reviewer guide
- Verify the updated compose command for the CRM service.
- Verify the auth seeding path uses `db:create && db:migrate` before `db:seed`.
- From a clean environment (`down -v`), confirm both services’ migrations are applied and the app boots without missing tables.

## Checklist
- [x] Conventional Commit in title
- [x] Compose command updated (CRM)
- [x] Setup/seeding updated (Auth)
- [x] Manual test plan included
- [x] Linked issue provided (#64)
- [x] No DB migrations added by this PR
- [x] CONTRIBUTING guidelines followed (target `develop`)
