### PR TITLE
ci(event-names): add cross-repo EVENT_NAMES sync gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,27 +60,20 @@ jobs:
   event-names-sync:
     name: EvoFlow event-names sync
     runs-on: ubuntu-latest
-    # No `paths:` filter at the workflow level (the workflow guards other jobs
-    # too), so this job short-circuits via a path check when nothing relevant
-    # changed. Cost is one ~5s job otherwise.
+    # Always-on (~5s of pure bash). The previous "Detect relevant changes"
+    # gate filtered by file paths, which was silently skipped on the workflow
+    # that needs the gate the most: submodule-pointer bumps. `git diff
+    # --name-only` for a bump emits the submodule directory as a bare line
+    # (e.g. `evo-ai-crm-community`), which the `^evo-ai-crm-community/lib/…`
+    # regex did not match — so the check was bypassed precisely when one
+    # submodule moved to a new event_names list and the other did not.
+    # Cheaper to run unconditionally than to chase regex coverage for every
+    # diff shape git can emit.
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Detect relevant changes
-        id: changed
-        run: |
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
-          if git diff --name-only "$base...$head" | grep -E '^(evo-ai-crm-community/lib/events/|evo-flow/src/modules/events/|scripts/check-event-names-sync\.sh|\.github/workflows/ci\.yml)' >/dev/null; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "No event-names-related files changed — skipping sync check."
-          fi
-
       - name: Check event_names sync
-        if: steps.changed.outputs.run == 'true'
         run: bash scripts/check-event-names-sync.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,31 @@ jobs:
         with:
           dockerfile: evo-ai-core-service-community/Dockerfile
           failure-threshold: error
+
+  event-names-sync:
+    name: EvoFlow event-names sync
+    runs-on: ubuntu-latest
+    # No `paths:` filter at the workflow level (the workflow guards other jobs
+    # too), so this job short-circuits via a path check when nothing relevant
+    # changed. Cost is one ~5s job otherwise.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$base...$head" | grep -E '^(evo-ai-crm-community/lib/events/|evo-flow/src/modules/events/|scripts/check-event-names-sync\.sh|\.github/workflows/ci\.yml)' >/dev/null; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No event-names-related files changed — skipping sync check."
+          fi
+
+      - name: Check event_names sync
+        if: steps.changed.outputs.run == 'true'
+        run: bash scripts/check-event-names-sync.sh

--- a/scripts/check-event-names-sync.sh
+++ b/scripts/check-event-names-sync.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Verifies that the CRM canonical event-names list and the evo-flow TS mirror
+# stay in lockstep. Pure Bash + grep — no Ruby/Node/jq runtime required.
+#
+#   Ruby source: evo-ai-crm-community/lib/events/evo_flow_event_names.rb
+#                (EvoFlow::EVENT_NAMES, %w[...] block)
+#   TS source:   evo-flow/src/modules/events/event-names.enum.ts
+#                (export const EVENT_NAMES = [ 'foo', 'bar', ... ] as const;)
+#
+# Exit 0 on match. Exit 1 on any of:
+#   - the two lists disagree (DIVERGENT)
+#   - the lists agree but the combined size != EXPECTED_COUNT (DIVERGENT count)
+# Exit 2 on missing source files.
+#
+# When the canonical list legitimately grows, bump EXPECTED_COUNT here in the
+# same PR that adds the entries — this is the gate that catches a 17-entry
+# Ruby list + 17-entry TS list that nobody told the integration story about.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXPECTED_COUNT=16
+
+RUBY_FILE="$REPO_ROOT/evo-ai-crm-community/lib/events/evo_flow_event_names.rb"
+TS_FILE="$REPO_ROOT/evo-flow/src/modules/events/event-names.enum.ts"
+
+for f in "$RUBY_FILE" "$TS_FILE"; do
+  if [[ ! -f "$f" ]]; then
+    echo "event_names_sync: ERROR — file not found: $f" >&2
+    exit 2
+  fi
+done
+
+# Ruby side: scope to the %w[ ... ] block, then tokenise on whitespace.
+ruby_list=$(
+  awk '
+    /%w\[/ { capture = 1; sub(/.*%w\[/, "") }
+    capture {
+      line = $0
+      if (sub(/\].*/, "", line)) { print line; capture = 0; exit }
+      print line
+    }
+  ' "$RUBY_FILE" | tr -s '[:space:]' '\n' | sed '/^$/d' | sort -u
+)
+
+# TS side: scope to the EVENT_NAMES = [ ... ] block, THEN extract single-quoted
+# literals. Anchoring to the block prevents a stray single-quoted string in a
+# comment, JSDoc, or future export from leaking into the canonical set.
+ts_list=$(
+  awk '
+    /EVENT_NAMES[[:space:]]*=[[:space:]]*\[/ { capture = 1 }
+    capture {
+      line = $0
+      if (match(line, /\]/)) { print substr(line, 1, RSTART - 1); capture = 0; exit }
+      print line
+    }
+  ' "$TS_FILE" | grep -oE "'[a-z][a-z._]*'" | tr -d "'" | sort -u
+)
+
+ruby_tmp=$(mktemp)
+ts_tmp=$(mktemp)
+diff_tmp=$(mktemp)
+trap 'rm -f "$ruby_tmp" "$ts_tmp" "$diff_tmp"' EXIT
+printf '%s\n' "$ruby_list" > "$ruby_tmp"
+printf '%s\n' "$ts_list" > "$ts_tmp"
+
+if ! diff -u "$ruby_tmp" "$ts_tmp" > "$diff_tmp"; then
+  echo "event_names_sync: DIVERGENT — see diff below"
+  echo "  (--- Ruby: $RUBY_FILE)"
+  echo "  (+++ TS:   $TS_FILE)"
+  cat "$diff_tmp"
+  exit 1
+fi
+
+count=$(wc -l < "$ruby_tmp" | tr -d '[:space:]')
+if [[ "$count" != "$EXPECTED_COUNT" ]]; then
+  echo "event_names_sync: DIVERGENT — lists match each other but count is $count (expected $EXPECTED_COUNT)."
+  echo "If this growth is intentional, bump EXPECTED_COUNT in $SCRIPT_DIR/check-event-names-sync.sh in the same PR."
+  exit 1
+fi
+
+echo "event_names_sync: OK ($EXPECTED_COUNT entries)"
+exit 0


### PR DESCRIPTION
## EVO-1241 — Cross-repo EVENT_NAMES sync gate (monorepo)

Terceira e última PR coordenada da story 7.5. CRM agora **raise** em `event_name` desconhecido; `evo-flow` agora **400** em `event` / `eventName` desconhecido. Esta PR adiciona o terceiro pilar: um job de CI que **bloqueia o merge** de qualquer PR que mexa em um lado da lista canônica sem mexer no outro.

Sem este gate, alguém adicionando `'order.placed'` só no CRM (ou só no TS) ia mergear, e o sistema voltava a ter silent data gap em produção até alguém perceber.

### Mudanças

| Arquivo | Mudança |
|---|---|
| `scripts/check-event-names-sync.sh` *(novo, `chmod +x`)* | Pure Bash, sem deps de runtime. Extrai a lista do Ruby (`%w[ ... ]` via awk scoped) e do TS (`EVENT_NAMES = [ ... ]` via awk scoped + `grep -oE "'...'"`), `sort -u` em ambos, `diff -u`. Exit 0 em match + `EXPECTED_COUNT=16`. Exit 1 com diff (DIVERGENT) caso contrário. |
| `.github/workflows/ci.yml` | Job novo `event-names-sync`. `submodules: recursive` + `fetch-depth: 0` (precisa do diff `base...head`). Step `Detect relevant changes` faz short-circuit quando nenhum arquivo relevante mudou no PR — não custa nada em PRs de docker/frontend. |

### Como o script lida com falsos positivos

**Antes do review adversarial:**
- Lado TS extraía com `grep -oE "'[a-z][a-z._]*'"` em **todo o arquivo**. Um comentário tipo `// see legacy 'foo.bar'` seria contado como evento canônico. Comentário no script afirmava "EVENT_NAMES is the only such block" — mas o regex não enforçava.

**Agora:**
- Lado TS faz `awk` scoped no bloco `EVENT_NAMES = [` … `]` **antes** do grep. Stray quoted strings em comentários ou outras consts são ignorados.
- Verificado em 3 paths: happy (OK), divergent (rename de um entry → DIVERGENT com diff + exit 1), scope (adiciona `'stray.name'` em comentário → OK, não conta).

### `EXPECTED_COUNT` — por quê

Hard-coded em `16`. Detecta o caso patológico em que alguém adiciona um entry em ambos os lados **simultaneamente** mas o restante do PR não toca a story 7.5 — i.e., crescer a lista sem coordenação com integration. Ao bumpar de 16 → 17, o autor é forçado a editar o script no mesmo commit, o que dispara revisão.

**Trade-off:** quando a lista cresce legitimamente, é uma **terceira edição obrigatória** (Ruby + TS + script). Documentado em ambos os READMEs (CRM + evo-flow).

### CI — short-circuit

```yaml
- name: Detect relevant changes
  id: changed
  run: |
    base="\${{ github.event.pull_request.base.sha }}"
    head="\${{ github.event.pull_request.head.sha }}"
    if git diff --name-only "\$base...\$head" | grep -E '^(evo-ai-crm-community/lib/events/|evo-flow/src/modules/events/|scripts/check-event-names-sync\.sh|\.github/workflows/ci\.yml)' >/dev/null; then
      echo "run=true" >> "\$GITHUB_OUTPUT"
    else
      echo "run=false" >> "\$GITHUB_OUTPUT"
      echo "No event-names-related files changed — skipping sync check."
    fi
```

Filtro em job-level (`paths:` no workflow) não cabe porque o workflow guarda `validate-compose` e `lint-dockerfiles` também — não dá pra restringir o trigger sem desligar os outros. Solução: short-circuit por step.

### Validação local

```
$ bash scripts/check-event-names-sync.sh
event_names_sync: OK (16 entries)
# exit 0

# Forçando divergence:
$ sed -i "s/'contact.created'/'contact.created.STRAY'/" \
    evo-flow/src/modules/events/event-names.enum.ts
$ bash scripts/check-event-names-sync.sh
event_names_sync: DIVERGENT — see diff below
  (--- Ruby: .../evo_flow_event_names.rb)
  (+++ TS:   .../event-names.enum.ts)
--- /tmp/...
+++ /tmp/...
@@ -2,7 +2,6 @@
 ...
-contact.created
 ...
# exit 1
```

| Check | Resultado |
|---|---|
| Happy path (16 entries match) | **OK** exit 0 |
| Divergent (rename 1 entry) | **DIVERGENT** exit 1 com diff |
| Scope test (stray quoted string em comentário) | **OK** exit 0 (ignorado) |
| YAML lint do workflow (`python3 -c 'import yaml; ...'`) | Jobs `validate-compose`, `lint-dockerfiles`, `event-names-sync` |

### PRs coordenadas (mesma branch)

Merge order: **CRM → evo-flow → esta PR**. O gate só roda meaningfully depois das duas primeiras mergeadas (precisa dos arquivos canônicos atualizados em `develop` de cada submodule).

- [evo-ai-crm-community#90](https://github.com/evolution-foundation/evo-ai-crm-community/pull/90) — `EvoFlow::InvalidEventName` + F4 exceptions
- [evo-flow#3](https://github.com/evolution-foundation/evo-flow/pull/3) — `@IsIn(EVENT_NAMES)` nos DTOs + e2e
- **monorepo (esta PR)** — sync script + CI job

### Out of Scope

- Filtro `paths:` no nível do workflow (interferiria com `validate-compose` / `lint-dockerfiles`). Short-circuit por step cobre o caso.
- Auto-derivar `EXPECTED_COUNT` de `git log` (overkill).
- Submodule pointer bumps no superprojeto (intencional — só PRs nas branches de develop dos submodules; sem ponteiro até as 3 mergearem).

### Test plan

- [ ] CI roda este job verde no primeiro PR depois do merge das duas primeiras.
- [ ] Confirmar que adicionar um entry só em um lado bloqueia o merge (test artificial em fork ou via PR de prova).
- [ ] Documentar no CHANGELOG da monorepo se houver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a CI gate to enforce synchronization between the canonical CRM Ruby event names list and the evo-flow TypeScript mirror.

New Features:
- Introduce a Bash script that validates the Ruby and TypeScript event name lists stay in sync and match an expected count.

Enhancements:
- Add a dedicated CI job that runs the event-names sync script and short-circuits when no relevant files have changed.

CI:
- Extend the main CI workflow with an event-names sync job that checks out submodules, detects relevant changes, and runs the sync verification script.