### PR TITLE
fix(docker): probe Temporal container IP in healthcheck (EVO-1755)

### DIFF
--- a/docker-compose.flow.yaml
+++ b/docker-compose.flow.yaml
@@ -141,14 +141,13 @@ services:
       - ./evo-flow/docker/temporal:/etc/temporal/config/dynamicconfig
     restart: unless-stopped
     healthcheck:
+      # Temporal binds to the container IP, not localhost — probe the real bind
+      # address so the check reflects actual availability (EVO-1755). $$ escapes
+      # the $ so compose passes a literal $(hostname -i) to the container shell.
       test:
         [
-          "CMD",
-          "tctl",
-          "--address",
-          "localhost:7233",
-          "workflow",
-          "list",
+          "CMD-SHELL",
+          "tctl --address $$(hostname -i):7233 workflow list",
         ]
       interval: 30s
       timeout: 10s


### PR DESCRIPTION
## Summary
The `evo-campaign-temporal` container healthcheck ran `tctl --address localhost:7233`, but Temporal binds to the **container IP**, so the check always failed and the container showed `(unhealthy)` while serving normally — blocking/flapping any dependent gated on `depends_on: condition: service_healthy`. Now probes the real bind address via `CMD-SHELL` + `$(hostname -i):7233`.

## Live validation (against the running Temporal)
- `docker ps` before: `evo-campaign-temporal  Up 31 hours (unhealthy)` — false, it was serving fine on container IP `172.18.0.4`.
- Same live container, both commands:
  - OLD `tctl --address localhost:7233 workflow list` → **exit 1** (`connection refused dial tcp [::1]:7233`).
  - NEW `tctl --address $(hostname -i):7233 workflow list` → **exit 0** (lists workflows).
- After `docker compose -f docker-compose.flow.yaml up -d --force-recreate evo-campaign-temporal` → **`Up (healthy)` within ~6s**; last health-check log exit 0.
- Image check (`temporalio/auto-setup:1.24.2`): `tctl` (`/usr/local/bin/tctl`) + `hostname` present; `hostname -i` returns a single IP.

## Notes
- `$$` escapes the `$` so compose passes a literal `$(hostname -i)` to the container shell (verified in the recreated container's `Config.Healthcheck.Test`).
- The container is on a single network, so `hostname -i` returns one IP. If it ever joins a second network, guard with `| awk '{print $1}'`.
- Out of scope (separate cards): worker poll resilience + zero-poller alerting (EVO-1758); app-level readiness that the worker is polling `journey-execution` (EVO-1226).

## Validation
- `docker compose -f docker-compose.flow.yaml config` → exit 0, no warnings; healthcheck resolves
- YAML parse → OK
- Live recreate → `healthy`

## Changed Files
- `docker-compose.flow.yaml`

## Linked Issue
- EVO-1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix Temporal container healthcheck so it no longer fails when Temporal binds to the container IP rather than localhost.