### PR TITLE
fix(compose): set EVO_AUTH_BASE_URL on evo-processor (EVO-1683)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,12 +229,15 @@ services:
       PORT: "8000"
       EVO_AI_CRM_URL: http://evo-crm:3000
       CORE_SERVICE_URL: http://evo-core:5555/api/v1
+      EVO_AUTH_BASE_URL: http://evo-auth:3001
     volumes:
       - processor_logs:/app/logs
     depends_on:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      evo-auth:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]


### PR DESCRIPTION
## Summary
- Adiciona `EVO_AUTH_BASE_URL: http://evo-auth:3001` no `environment` do serviço `evo-processor`
- Adiciona `evo-auth` ao `depends_on` do `evo-processor` (`condition: service_healthy`) para garantir ordem de subida

## Why
Processor caía no default `localhost:3001` (de `src/config/settings.py:51`) e retornava `503 ERR_SERVICE_UNAVAILABLE` ao validar bearer token, com log `EvoAuth: Network error for POST /api/v1/auth/validate: All connection attempts failed`. Cliente precisava aplicar workaround manual no compose.

Agora alinha com `evo-core`, que já consome o mesmo host via `EVO_AUTH_BASE_URL` (corrigindo nome de var citado erroneamente como `EVO_AUTH_SERVICE_URL` no commit body — quem usa essa variante é `evo-crm`/`evo-crm-sidekiq`).

## Validation
- `docker compose config` parseia OK
- `evo-processor` em `docker compose config`:
  - `EVO_AUTH_BASE_URL: http://evo-auth:3001` ✅
  - `depends_on: [evo-auth, postgres, redis]` ✅
- Container recreated + smoke manual: `docker compose exec evo-processor env | grep EVO_AUTH_BASE_URL` → `http://evo-auth:3001`
- Reachability: `python -c "urllib.request.urlopen('http://evo-auth:3001/up')"` → HTTP 200
- Logs do processor: `Token validation successful for user: admin@evo.local` (zero `All connection attempts failed`)

## Out of scope (deliberadamente)
- `evo-core` também não tem `depends_on: evo-auth`. Tecnicamente o mesmo padrão, mas sem evidência de incidente reportado e Rails tem retry no boot que mascara a janela. Vira card próprio se aparecer relato.
- Fix defensivo no `settings.py` default (issue §4, marcado como opcional). Fix primário no compose já destrava o cliente.

## Changed Files
- `docker-compose.yml`

## Linked Issue
- EVO-1683