### PR TITLE
fix(compose): VITE_EVOFLOW_API_URL evo-frontend (EVO-1906)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,7 @@ services:
       VITE_WS_URL: ${VITE_WS_URL:-http://localhost:3000}
       VITE_EVOAI_API_URL: ${VITE_EVOAI_API_URL:-http://localhost:5555}
       VITE_AGENT_PROCESSOR_URL: ${VITE_AGENT_PROCESSOR_URL:-http://localhost:8000}
+      VITE_EVOFLOW_API_URL: ${VITE_EVOFLOW_API_URL:-http://localhost:3334}
     ports:
       - "5173:80"
     depends_on:


### PR DESCRIPTION
## Resumo

3ª camada do fix do defeito D17 (e2e jornadas). Adiciona `VITE_EVOFLOW_API_URL: ${VITE_EVOFLOW_API_URL:-http://localhost:3334}` ao bloco `environment` do serviço `evo-frontend` no `docker-compose.yml`, para que o entrypoint do FE dockerizado receba a URL e substitua o placeholder no bundle.

Sem esta var, o `apiEvoFlow` chama `undefined/api/v1/journeys` (e segments, contact-events) → painel "No journeys configured" e listas vazias.

## Test plan

- Mudança é uma linha de `environment` no compose, simétrica às outras 5 vars VITE_*. Validação real: rebuild + recreate do `evo-frontend` e checar o painel de jornadas.

## Notas

PR companheiro (camadas 1-2: placeholder no Dockerfile + sed no entrypoint) no repo do FE: evolution-foundation/evo-ai-frontend-community#193. Ambos necessários para o fix completo. Este PR NÃO bumpa ponteiros de submodule.

## Summary by Sourcery

Bug Fixes:
- Ensure the dockerized evo-frontend uses a defined EvoFlow API base URL instead of calling undefined paths for journeys and related resources.