### PR TITLE
fix(media): doc ACTIVE_STORAGE_URL + Linux host.docker.internal alias (EVO-1747)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,12 @@ SMTP_PASSWORD=
 
 # Storage — local filesystem in development
 ACTIVE_STORAGE_SERVICE=local
+# Public/internal host used to build ActiveStorage URLs.
+# Required when ACTIVE_STORAGE_SERVICE=local — without it the browser renders broken
+# media ("grey blob") and Evolution API fails to fetch outbound attachments.
+# In dev: host.docker.internal lets sibling containers reach the host's localhost.
+# In prod: set to the public CRM domain (e.g. https://crm.example.com).
+ACTIVE_STORAGE_URL=http://host.docker.internal:3000
 
 # Sidekiq
 SIDEKIQ_CONCURRENCY=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,12 @@ services:
     ports:
       - "3000:3000"
     env_file: .env
+    # host.docker.internal is provided by Docker Desktop on macOS/Windows but
+    # NOT by stock Docker Engine on Linux — the extra_hosts entry below mirrors
+    # the Desktop alias for parity, so ACTIVE_STORAGE_URL=http://host.docker.internal:3000
+    # (see .env.example) works across all platforms (EVO-1747).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       RAILS_ENV: ${RAILS_ENV:-development}
       REDIS_URL: redis://:${REDIS_PASSWORD:-evoai_redis_pass}@redis:6379/0
@@ -149,6 +155,10 @@ services:
         RAILS_SERVE_STATIC_FILES: "false"
     restart: unless-stopped
     env_file: .env
+    # Same Linux/Desktop parity alias as evo-crm — Sidekiq jobs also generate
+    # ActiveStorage URLs (Evolution send path) and need to reach host:3000.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       RAILS_ENV: ${RAILS_ENV:-development}
       REDIS_URL: redis://:${REDIS_PASSWORD:-evoai_redis_pass}@redis:6379/0


### PR DESCRIPTION
## Summary
- `.env.example` documenta `ACTIVE_STORAGE_URL` com defaults dev (`http://host.docker.internal:3000`) e nota pra prod (domínio público)
- `docker-compose.yml` adiciona `extra_hosts: "host.docker.internal:host-gateway"` em `evo-crm` e `evo-crm-sidekiq` — paridade Linux/Mac/Windows (Docker Engine no Linux não fornece o alias por default)
- Bump do submódulo `evo-ai-crm-community` para incluir o fix da PR #179

## Why
Sem esta config + sem o fix do submódulo, mídias com storage local NÃO renderizam no chat (bolinha cinza) E containers irmãos como Evolution API não conseguem baixar o arquivo (envio outbound se perde silenciosamente).

## Validation
- `evo-crm-community: docker compose up -d` + envio manual de imagem → renderiza no chat E destinatário recebe no WhatsApp
- `evo-crm-community: docker compose exec evolution_api wget http://host.docker.internal:3000/...` → HTTP 404 (conecta no host, antes era connection refused)

## Changed Files
- `.env.example`
- `docker-compose.yml`
- `evo-ai-crm-community` (submodule pointer)

## Linked Issue
- EVO-1747 — Fase 1 desta entrega

## Companion PR
- `evo-ai-crm-community#179`: fix do código + specs + warning de boot

## Summary by Sourcery

Ensure local Active Storage media URLs resolve consistently across environments and align submodule with related media handling fixes.

Deployment:
- Add host.docker.internal host-gateway alias to evo-crm and evo-crm-sidekiq services in docker-compose for cross-platform host access.

Documentation:
- Document ACTIVE_STORAGE_URL defaults for development and production in .env.example.

Chores:
- Update evo-ai-crm-community submodule pointer to include upstream media handling fix.