### PR TITLE
fix(prod-test): healthcheck do evo_crm usa wget /health/live (EVO-1966)

### DIFF
--- a/docker-compose.prod-test.yaml
+++ b/docker-compose.prod-test.yaml
@@ -177,7 +177,7 @@ services:
       evo_auth:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/auth/sign_in"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/health/live"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Description

Corrige o **bloqueante do prod-test** apontado na review do EVO-1966: o healthcheck do `evo_crm` em `docker-compose.prod-test.yaml` usava `curl -f http://localhost:3000/auth/sign_in`, mas:

- a imagem publicada `evoapicloud/evo-ai-crm-community:latest` traz **`wget`, não `curl`** (verificado: `curl` ausente, `wget` em `/usr/bin/wget`);
- `/auth/sign_in` **não é rota da CRM** (o `routes.rb` expõe `/health/live`).

Resultado: o healthcheck falhava eternamente → `evo_crm` nunca ficava `healthy` → `evo_gateway` (`depends_on: service_healthy`) nunca subia → prod-test inutilizável (AC#2).

**Fix (1 linha):** troca por `wget --spider` no endpoint de liveness `/health/live`, espelhando o healthcheck do dev (`docker-compose.yml`) e o fix já aplicado ao core (commit `47fd96f`: wget, `/health`, IPv4).

```diff
- test: ["CMD", "curl", "-f", "http://localhost:3000/auth/sign_in"]
+ test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/health/live"]
```

### Validação local (empírica, na `:latest` publicada)

1. **Isolado** — container da `:latest` com o comando exato do healthcheck → Docker `healthy` (exit 0, `/health/live` → `{"status":"alive"}`).
2. **In-situ pelo compose** — `docker compose -f docker-compose.prod-test.yaml up -d --wait evo_gateway` → exit 0: `evo_crm` **healthy** (via a stanza corrigida), `evo_auth` healthy, `evo_gateway` **running**, gateway respondendo em `:3030` (HTTP 406, não mais connection-refused).

### Fora de escopo (deixado explícito)

Este PR faz o stack **subir**. Ele **não** resolve o 404 da tela unificada de Modelos de Mensagem: a `:latest` continua defasada de conteúdo (sem o controller/rota flat `/api/v1/message_templates` do EVO-1716). Isso depende de **republicar a `:latest` do fonte atual** — a diretriz de paridade do card, tratada separadamente.

Ref: EVO-1966

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] CI/CD
- [ ] Refactor
- [ ] Other:

## Service(s) Affected

- [ ] Auth Service (`evo-auth-service-community`)
- [ ] CRM Service (`evo-ai-crm-community`)
- [ ] Frontend (`evo-ai-frontend-community`)
- [ ] Processor (`evo-ai-processor-community`)
- [ ] Core Service (`evo-ai-core-service-community`)
- [x] Root / Infrastructure (docker-compose, Makefile, CI/CD, docs)

## Checklist

- [x] I have tested this locally
- [ ] I have updated documentation (if applicable)
- [x] This does not introduce breaking changes
- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## Screenshots

N/A

## Summary by Sourcery

Bug Fixes:
- Correct evo_crm healthcheck in docker-compose.prod-test to use wget against the /health/live endpoint instead of an invalid curl-based sign-in check.