### PR TITLE
refactor(review): stack de review em internal/ + review.sh (deleta prod-test) (EVO-1998)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
   # Core Service (Go / Gin) — Port 5555
   # ---------------------------------------------------------------------------
   evo-core:
-    # Pulled from Docker Hub — same public image used by prod-test and swarm.
+    # Pulled from Docker Hub — same public image used by swarm.
     # (To develop the Core locally, swap this for a `build:` against
     # ./evo-ai-core-service-community using a community modfile.)
     image: evoapicloud/evo-ai-core-service-community:latest

--- a/docs/SETUP-GUIDE.md
+++ b/docs/SETUP-GUIDE.md
@@ -15,10 +15,6 @@ There are exactly **two** supported ways to run the stack:
 > Redis, RabbitMQ, ClickHouse and on service-to-service URLs that are wired by
 > the compose/stack files. Running a single service with `docker run` will not
 > bring up a usable environment. Use one of the two methods above.
->
-> A third file, `docker-compose.prod-test.yaml`, exists only to *simulate* the
-> production stack locally (production images + nginx gateway). It is a testing
-> aid, not a deployment target — see the file header for required env vars.
 
 ## Prerequisites
 
@@ -87,7 +83,7 @@ replaces `VITE_*_PLACEHOLDER` tokens), so changing one only needs
 
 In development, `evo-core` pulls the public image
 `evoapicloud/evo-ai-core-service-community:latest` from Docker Hub — the same
-image used by `prod-test` and `swarm`. No local Go build is required.
+image used by `swarm`. No local Go build is required.
 
 To develop the Core locally instead, swap the `image:` line for a `build:`
 against `./evo-ai-core-service-community` (a separate community Go module file —

--- a/internal/review/README.md
+++ b/internal/review/README.md
@@ -1,0 +1,48 @@
+# Review environment (internal team tooling)
+
+**Not** part of the self-host quick start — self-hosters use the root
+`docker-compose.yml` (`make setup`). This stack exists to **test a card's PRs
+running**: it pulls the published Docker Hub images and lets you pin one (or
+several) services to a PR image while the rest run `:develop`.
+
+## Image tags
+
+| env var         | service                        | default   |
+|-----------------|--------------------------------|-----------|
+| `CRM_TAG`       | evo-ai-crm-community           | `develop` |
+| `AUTH_TAG`      | evo-auth-service-community     | `develop` |
+| `CORE_TAG`      | evo-ai-core-service-community  | `develop` |
+| `PROCESSOR_TAG` | evo-ai-processor-community     | `develop` |
+| `BOT_TAG`       | evo-bot-runtime                | `develop` |
+| `FRONTEND_TAG`  | evo-ai-frontend-community      | `develop` |
+
+PR images (`:pr-<N>`) are published by each service's CI on `pull_request`
+(see the service repo's `.github/workflows/docker-publish.yml`).
+
+## Usage
+
+Run from the repo root:
+
+```sh
+# whole develop line (baseline):
+BACKEND_URL=http://host.docker.internal:3030 \
+FRONTEND_URL=http://host.docker.internal:5173 \
+  docker compose -f internal/review/docker-compose.yml up -d
+
+# review CRM PR #140 against the rest of develop:
+CRM_TAG=pr-140 \
+BACKEND_URL=http://host.docker.internal:3030 \
+FRONTEND_URL=http://host.docker.internal:5173 \
+  docker compose -f internal/review/docker-compose.yml up -d
+
+# tear down (and wipe volumes):
+docker compose -f internal/review/docker-compose.yml down -v
+```
+
+`BACKEND_URL`/`FRONTEND_URL` must be **non-localhost** (the CRM refuses to boot
+in production mode with localhost). On Mac/Windows `host.docker.internal` works;
+on Linux use the host LAN IP or add an `extra_hosts` mapping.
+
+> The card→PRs resolution (which PR maps to which `<SVC>_TAG`) is done by Claude
+> via the Linear MCP — see the `review-card` / `evo-code-review` skills. This
+> compose only consumes the tags. Tracking: **EVO-1998**.

--- a/internal/review/README.md
+++ b/internal/review/README.md
@@ -19,7 +19,26 @@ several) services to a PR image while the rest run `:develop`.
 PR images (`:pr-<N>`) are published by each service's CI on `pull_request`
 (see the service repo's `.github/workflows/docker-publish.yml`).
 
-## Usage
+## Quick use — `review.sh`
+
+Pass one or more PR URLs; each pins its service to `:pr-<N>`, all other services
+run `:develop`, then the stack comes up:
+
+```sh
+# one PR:
+./internal/review/review.sh https://github.com/evolution-foundation/evo-ai-crm-community/pull/140
+# a card with several PRs — just pass all the links:
+./internal/review/review.sh <crm-pr-url> <auth-pr-url>
+# dry-run (prints what it would do, boots nothing):
+./internal/review/review.sh -n <pr-url>
+# baseline (no args → every service on :develop):
+./internal/review/review.sh
+```
+
+`review.sh` is the intended entry point. The raw `docker compose` commands below
+are the plumbing it drives.
+
+## Usage (plumbing)
 
 Run from the repo root:
 

--- a/internal/review/docker-compose.yml
+++ b/internal/review/docker-compose.yml
@@ -1,20 +1,25 @@
 # =============================================================================
-# Evo CRM Community - Local Production Test
+# Evo CRM Community — Review environment  (INTERNAL team tooling)
 # =============================================================================
-# Simulates the production swarm stack locally using docker compose.
-# Uses the same Docker Hub images that would run in production.
+# NOT part of the self-host quick start. Runs the published Docker Hub images
+# as a full local stack so a reviewer can TEST a card's changes running.
+# See internal/review/README.md.
 #
-# RAILS_ENV is set to production, so BACKEND_URL and FRONTEND_URL must be
-# non-localhost values (the CRM refuses to boot in production with localhost).
-# On Mac/Windows: host.docker.internal works out of the box.
-# On Linux: use the host LAN IP or add extra_hosts mapping.
+# The image tag of each service is overridable via env:
+#   - no override      → every service runs :develop (the review baseline)
+#   - <SVC>_TAG=pr-<N> → pins that service to its PR image (:pr-N)
+#   tag vars: CRM_TAG, AUTH_TAG, CORE_TAG, PROCESSOR_TAG, BOT_TAG, FRONTEND_TAG
 #
-# Usage:
+# RAILS_ENV=production, so BACKEND_URL and FRONTEND_URL must be non-localhost
+# (the CRM refuses to boot in production with localhost). On Mac/Windows,
+# host.docker.internal works; on Linux use the host LAN IP or extra_hosts.
+#
+# Example — review CRM PR #140 against the rest of develop:
+#   CRM_TAG=pr-140 \
 #   BACKEND_URL=http://host.docker.internal:3030 \
 #   FRONTEND_URL=http://host.docker.internal:5173 \
-#     docker compose -f docker-compose.prod-test.yaml up -d
-#   docker compose -f docker-compose.prod-test.yaml logs -f
-#   docker compose -f docker-compose.prod-test.yaml down -v
+#     docker compose -f internal/review/docker-compose.yml up -d
+#   docker compose -f internal/review/docker-compose.yml down -v
 # =============================================================================
 
 services:
@@ -57,7 +62,7 @@ services:
   # ---------------------------------------------------------------------------
   evo_gateway:
     build:
-      context: ./nginx
+      context: ../../nginx
       dockerfile: Dockerfile
     ports:
       - "3030:3030"
@@ -71,7 +76,7 @@ services:
   # Auth Service (Ruby / Rails) — Port 3001
   # ---------------------------------------------------------------------------
   evo_auth:
-    image: evoapicloud/evo-auth-service-community:latest
+    image: evoapicloud/evo-auth-service-community:${AUTH_TAG:-develop}
     command: sh -c "bundle exec rails db:prepare && bundle exec rails s -p 3001 -b 0.0.0.0"
     ports:
       - "3001:3001"
@@ -87,7 +92,7 @@ services:
       POSTGRES_PASSWORD: evoai_dev_password
       POSTGRES_DATABASE: evo_community
       REDIS_URL: redis://:evoai_redis_pass@evo_redis:6379/1
-      FRONTEND_URL: "${FRONTEND_URL:?FRONTEND_URL must be set to a non-localhost URL for prod-test (e.g. http://host.docker.internal:5173)}"
+      FRONTEND_URL: "${FRONTEND_URL:?FRONTEND_URL must be set to a non-localhost URL for the review env (e.g. http://host.docker.internal:5173)}"
       MAILER_SENDER_EMAIL: noreply@evoai.local
       DOORKEEPER_JWT_SECRET_KEY: "a]i9F#k2$$Lm7Nq0R!sT4uW6xZ8bD1eG3hJ5oP7rV9yAcE2fH4jM6pS8vX0zB3dK5nQ7tU9wY1"
       DOORKEEPER_JWT_ALGORITHM: hs256
@@ -108,7 +113,7 @@ services:
       start_period: 90s
 
   evo_auth_sidekiq:
-    image: evoapicloud/evo-auth-service-community:latest
+    image: evoapicloud/evo-auth-service-community:${AUTH_TAG:-develop}
     command: sh -c "bundle exec sidekiq"
     # Disable inherited HTTP healthcheck — Sidekiq has no web server.
     healthcheck:
@@ -135,7 +140,7 @@ services:
   # CRM Service (Ruby / Rails) — Port 3000
   # ---------------------------------------------------------------------------
   evo_crm:
-    image: evoapicloud/evo-ai-crm-community:latest
+    image: evoapicloud/evo-ai-crm-community:${CRM_TAG:-develop}
     command: sh -c "bundle exec rails db:prepare && bundle exec rails s -p 3000 -b 0.0.0.0"
     ports:
       - "3000:3000"
@@ -154,8 +159,8 @@ services:
       REDIS_URL: redis://:evoai_redis_pass@evo_redis:6379/0
       EVO_AUTH_SERVICE_URL: http://evo_auth:3001
       EVO_AI_CORE_SERVICE_URL: http://evo_core:5555
-      BACKEND_URL: "${BACKEND_URL:?BACKEND_URL must be set to a non-localhost URL for prod-test (e.g. http://host.docker.internal:3030)}"
-      FRONTEND_URL: "${FRONTEND_URL:?FRONTEND_URL must be set to a non-localhost URL for prod-test (e.g. http://host.docker.internal:5173)}"
+      BACKEND_URL: "${BACKEND_URL:?BACKEND_URL must be set to a non-localhost URL for the review env (e.g. http://host.docker.internal:3030)}"
+      FRONTEND_URL: "${FRONTEND_URL:?FRONTEND_URL must be set to a non-localhost URL for the review env (e.g. http://host.docker.internal:5173)}"
       # CORS origins are the browser's Origin header (Vite serves on localhost:5173 from the host machine);
       # they are independent of BACKEND_URL/FRONTEND_URL which are CRM-side URLs.
       CORS_ORIGINS: "${CORS_ORIGINS:-http://localhost:5173,http://localhost:3030}"
@@ -182,7 +187,7 @@ services:
       start_period: 120s
 
   evo_crm_sidekiq:
-    image: evoapicloud/evo-ai-crm-community:latest
+    image: evoapicloud/evo-ai-crm-community:${CRM_TAG:-develop}
     command: ["bundle", "exec", "sidekiq", "-C", "config/sidekiq.yml"]
     # Disable inherited HTTP healthcheck — Sidekiq has no web server.
     healthcheck:
@@ -213,7 +218,7 @@ services:
   # Core Service (Go / Gin) — Port 5555
   # ---------------------------------------------------------------------------
   evo_core:
-    image: evoapicloud/evo-ai-core-service-community:latest
+    image: evoapicloud/evo-ai-core-service-community:${CORE_TAG:-develop}
     ports:
       - "5555:5555"
     environment:
@@ -244,7 +249,7 @@ services:
   # Processor Service (Python / FastAPI) — Port 8000
   # ---------------------------------------------------------------------------
   evo_processor:
-    image: evoapicloud/evo-ai-processor-community:latest
+    image: evoapicloud/evo-ai-processor-community:${PROCESSOR_TAG:-develop}
     ports:
       - "8000:8000"
     environment:
@@ -285,7 +290,7 @@ services:
   # Bot Runtime (Go / Gin) — Port 8080
   # ---------------------------------------------------------------------------
   evo_bot_runtime:
-    image: evoapicloud/evo-bot-runtime:latest
+    image: evoapicloud/evo-bot-runtime:${BOT_TAG:-develop}
     ports:
       - "8080:8080"
     environment:
@@ -302,7 +307,7 @@ services:
   # Frontend (React / Vite / Nginx) — Port 5173
   # ---------------------------------------------------------------------------
   evo_frontend:
-    image: evoapicloud/evo-ai-frontend-community:latest
+    image: evoapicloud/evo-ai-frontend-community:${FRONTEND_TAG:-develop}
     ports:
       - "5173:80"
     environment:

--- a/internal/review/review.sh
+++ b/internal/review/review.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# review — sobe a stack de review com um ou mais serviços fixados na imagem do seu PR.
+#
+#   review <pr-url> [<pr-url> ...]
+#
+# Cada URL de PR (https://github.com/<org>/<repo>/pull/<N>) fixa o serviço daquele
+# repo em :pr-<N>; todos os outros rodam :develop. Depois sobe a stack.
+#
+# Um card com vários PRs? Passe todos os links: o revisor copia do card.
+# Sem argumentos = baseline (tudo em :develop).
+#
+# Flags:
+#   -n, --dry-run   mostra o que rodaria (env + comando compose) sem subir nada.
+#
+# Exemplos:
+#   ./review.sh https://github.com/evolution-foundation/evo-ai-crm-community/pull/140
+#   ./review.sh <crm-pr-url> <auth-pr-url>
+#   ./review.sh -n <crm-pr-url>
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE="$SCRIPT_DIR/docker-compose.yml"
+
+DRY_RUN=0
+declare -a URLS=()
+for arg in "$@"; do
+  case "$arg" in
+    -n|--dry-run) DRY_RUN=1 ;;
+    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) URLS+=("$arg") ;;
+  esac
+done
+
+# repo do PR -> variável de tag do serviço no compose
+repo_to_tagvar() {
+  case "$1" in
+    evo-ai-crm-community)          echo "CRM_TAG" ;;
+    evo-auth-service-community)    echo "AUTH_TAG" ;;
+    evo-ai-core-service-community) echo "CORE_TAG" ;;
+    evo-ai-processor-community)    echo "PROCESSOR_TAG" ;;
+    evo-bot-runtime)               echo "BOT_TAG" ;;
+    evo-ai-frontend-community)     echo "FRONTEND_TAG" ;;
+    *) echo "" ;;
+  esac
+}
+
+declare -a TAG_ENVS=()
+declare -a SUMMARY=()
+
+for url in "${URLS[@]:-}"; do
+  [ -z "$url" ] && continue
+  if [[ "$url" =~ github\.com/[^/]+/([^/]+)/pull/([0-9]+) ]]; then
+    repo="${BASH_REMATCH[1]}"; num="${BASH_REMATCH[2]}"
+  else
+    echo "erro: não é URL de PR do GitHub: $url" >&2; exit 1
+  fi
+  var="$(repo_to_tagvar "$repo")"
+  if [ -z "$var" ]; then
+    echo "erro: repo '$repo' não é um serviço da stack de review" >&2; exit 1
+  fi
+  tag="pr-${num}"
+  img="evoapicloud/${repo}:${tag}"
+  if ! docker manifest inspect "$img" >/dev/null 2>&1; then
+    echo "aviso: imagem $img ainda não existe no registry — o build do PR já terminou?" >&2
+  fi
+  TAG_ENVS+=("${var}=${tag}")
+  SUMMARY+=("${repo} → ${tag}")
+done
+
+# URLs de review (não-localhost — o CRM recusa boot em produção com localhost)
+export BACKEND_URL="${BACKEND_URL:-http://host.docker.internal:3030}"
+export FRONTEND_URL="${FRONTEND_URL:-http://host.docker.internal:5173}"
+
+echo "Stack de review:"
+if [ "${#SUMMARY[@]}" -eq 0 ]; then
+  echo "  - (todos os serviços → develop)"
+else
+  for s in "${SUMMARY[@]}"; do echo "  - $s"; done
+  echo "  - (demais serviços → develop)"
+fi
+echo
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "[dry-run] rodaria:"
+  echo "  ${TAG_ENVS[*]} \\"
+  echo "  BACKEND_URL=$BACKEND_URL FRONTEND_URL=$FRONTEND_URL \\"
+  echo "  docker compose -f $COMPOSE up -d"
+  exit 0
+fi
+
+if [ "${#TAG_ENVS[@]}" -eq 0 ]; then
+  docker compose -f "$COMPOSE" up -d
+else
+  env "${TAG_ENVS[@]}" docker compose -f "$COMPOSE" up -d
+fi
+
+echo
+echo "Gateway:  $BACKEND_URL"
+echo "Frontend: $FRONTEND_URL"
+echo "Derrubar: docker compose -f $COMPOSE down -v"

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -23,8 +23,9 @@ Full path matrix is in [`default.conf.template`](./default.conf.template).
 
 Each of the five variables above is rendered at container start from an
 environment variable. The defaults below (`evo_auth`, `evo_crm`, …) match the
-underscore service names used by **`docker-compose.prod-test.yaml`**, which is
-the only stack that runs this gateway against the default hostnames.
+underscore service names used by **`internal/review/docker-compose.yml`** (the
+review environment), which is the only stack that runs this gateway against the
+default hostnames.
 
 Two stacks do **not** match these defaults:
 


### PR DESCRIPTION
## Description

Reorganiza o teste local por imagem publicada: **deleta o `docker-compose.prod-test.yaml` do root** e o transforma na **stack de review parametrizada por tag**, fora da cara do self-hoster — e adiciona o `review.sh`, que é o comando do revisor.

**Por quê deletar o prod-test:** ninguém usava num fluxo — `Makefile`/`setup.sh` não o chamam, e a própria `SETUP-GUIDE.md` dizia *"exists only to simulate production"*. O papel dele (rodar as imagens publicadas numa stack local) é exatamente o da stack de review, então foi repurposed em vez de duplicado.

### O que muda

- **`internal/review/docker-compose.yml`** — clone do prod-test com **tag por serviço** (`image: evoapicloud/<svc>:${<SVC>_TAG:-develop}`). Sem override → tudo em `:develop`; `<SVC>_TAG=pr-<N>` fixa um serviço na imagem do seu PR. `context` do gateway ajustado (`../../nginx`).
- **`internal/review/review.sh`** — `review.sh <pr-url> [<pr-url> ...]`: parseia cada link, mapeia repo→serviço, fixa `<SVC>_TAG=pr-N` (resto `develop`) e sobe a stack. Vários PRs = vários args (o revisor copia os links do card). `-n` = dry-run; sem args = baseline develop. Avisa se a imagem `:pr-N` ainda não foi publicada.
- **`internal/review/README.md`** — deixa explícito que é tooling **interno de review**, não o quick start de self-host.
- **`SETUP-GUIDE.md` / `nginx/README.md` / `docker-compose.yml`** — removidas as referências ao prod-test (deletado).

Root fica só com o que o self-hoster precisa: `docker-compose.yml` (dev) e `docker-compose.swarm.yaml` (deploy).

### Validação

- `docker compose -f internal/review/docker-compose.yml config` parseia; `CRM_TAG=pr-140` fixa só o CRM (resto `develop`); gateway resolve `../../nginx`.
- `review.sh` testado (dry-run: 1 PR, multi-PR, baseline, URL inválida).
- **Stack inteira subiu healthy** em `:develop` num teste local (9 serviços, `crm`+`auth` healthy, gateway respondendo).

### Notas

- **Supersede o prod-test:** o critério do **EVO-1966** *"docker-compose.prod-test.yaml sobe ambiente funcional"* fica sem objeto — a stack de review assume esse papel.
- Par com **evo-claude PR #4**: a skill `evo-code-review` chama o `review.sh` a partir dos PRs de um card.
- Ref: **EVO-1998**.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] CI/CD
- [x] Refactor
- [x] Other: tooling interno de review

## Service(s) Affected

- [ ] Auth Service (`evo-auth-service-community`)
- [ ] CRM Service (`evo-ai-crm-community`)
- [ ] Frontend (`evo-ai-frontend-community`)
- [ ] Processor (`evo-ai-processor-community`)
- [ ] Core Service (`evo-ai-core-service-community`)
- [x] Root / Infrastructure (docker-compose, Makefile, CI/CD, docs)

## Checklist

- [x] I have tested this locally
- [x] I have updated documentation (if applicable)
- [x] This does not introduce breaking changes
- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## Screenshots

N/A

## Summary by Sourcery

Refactor the old local prod-test compose into an internal, tag-parameterized review environment with a helper script and updated documentation, while removing the obsolete prod-test entry point from the root stack.

New Features:
- Add an internal review Docker Compose stack that runs published images with per-service tag overrides for PR testing
- Add a review.sh helper script to spin up the review stack from one or more GitHub PR URLs with optional dry-run mode

Enhancements:
- Move the former prod-test stack into internal/review and retarget it as the dedicated review environment with tag-based images
- Adjust the gateway build context and image tagging to default all services to the develop baseline while allowing PR-specific overrides

Documentation:
- Document the internal review environment and its usage, clarifying that it is not part of the self-host quick start
- Remove references to the deprecated prod-test compose file from setup and nginx documentation and update comments about image usage