### PR TITLE
fix(ci): bump auth submodule + guard robustness (EVO-1911 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,14 @@ jobs:
         with:
           dockerfile: evo-ai-core-service-community/Dockerfile
           failure-threshold: error
+
+  check-migration-collision:
+    name: Check Migration Version Collision (CRM vs auth)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Run migration collision guard
+        run: ./scripts/check_migration_collision.sh

--- a/scripts/README-migration-guard.md
+++ b/scripts/README-migration-guard.md
@@ -1,0 +1,68 @@
+# Migration Version Collision Guard
+
+## What it checks
+
+CRM (`evo-ai-crm-community`) and auth (`evo-auth-service-community`) are both Rails apps that share the same local Postgres database and the same `schema_migrations` table. When both apps have a migration with the same 14-char version prefix, whichever migrates second is **silently skipped** by Rails, corrupting the schema.
+
+This guard fails when the two submodules have any overlapping version prefix in `db/migrate/`.
+
+## How to run locally
+
+From the umbrella root:
+
+```sh
+./scripts/check_migration_collision.sh
+```
+
+Exit codes: `0` no collision · `1` collision found · `2` unexpected repo state.
+
+## How to fix when it flags
+
+Renumber the offending migration in the repo with **fewer** migrations (auth, today) by adding 1 second to the timestamp:
+
+```sh
+cd evo-auth-service-community
+git mv db/migrate/YYYYMMDDHHMMSS_foo.rb db/migrate/YYYYMMDDHHMMS(S+1)_foo.rb
+```
+
+The class name inside the file does not need to change — Rails resolves migrations by class name, not filename.
+
+If `db/schema.rb` has `version:` equal to the renamed migration (i.e. it was the top migration), regenerate the schema:
+
+```sh
+RAILS_ENV=test bundle exec rails db:drop db:create db:migrate
+git add db/schema.rb
+```
+
+## Recovery — historical collision `20260622120000`
+
+If you migrated **auth first** on a local DB before this guard existed, `schema_migrations` will contain `20260622120000` while the CRM `messages.source` column is missing. Fix:
+
+```sh
+# Inside the CRM container:
+bundle exec rails runner 'puts ActiveRecord::Base.connection.column_exists?(:messages, :source)'
+# If false AND schema_migrations already contains 20260622120000:
+psql "$DATABASE_URL" -c "DELETE FROM schema_migrations WHERE version = '20260622120000';"
+bundle exec rails db:migrate
+```
+
+This is idempotent — safe to run whether or not `messages.source` already exists. Production is unaffected (never shared the DB).
+
+## Convention (recommended, not enforced)
+
+To reduce future collisions, prefer these hour ranges for new migrations:
+
+- CRM: `HH=12` (`YYYYMMDD_120000_*`)
+- auth: `HH=14` (`YYYYMMDD_140000_*`)
+
+The guard flags collisions regardless of hour — this is just a soft rule to make them less likely.
+
+## Limitations
+
+- The guard runs in CI **only on PRs to the umbrella** (`evo-crm-community`). PRs opened directly against `evo-ai-crm-community` or `evo-auth-service-community` are not blocked by this guard — the collision is caught when the submodule bump lands in an umbrella PR.
+- Only Rails/Rails collisions are checked. Other services (evo-flow via TypeORM) use a separate migration table and are out of scope.
+
+## Related
+
+- EVO-1911 — this guard.
+- EVO-1679 — DB-per-service split (deferred). Would eliminate the need for this guard.

--- a/scripts/README-migration-guard.md
+++ b/scripts/README-migration-guard.md
@@ -16,9 +16,20 @@ From the umbrella root:
 
 Exit codes: `0` no collision · `1` collision found · `2` unexpected repo state.
 
+### Reproducing CI behavior locally
+
+CI (`actions/checkout@v4` with `submodules: recursive`) reads the submodule SHAs **pinned in the umbrella tree**, not the tip of each submodule branch. If your working tree has newer submodule commits than what the umbrella records, the script will disagree with CI. To reproduce CI exactly:
+
+```sh
+git submodule update --init --recursive   # forces checkout of the pinned SHAs
+./scripts/check_migration_collision.sh
+```
+
+If this diverges from a run against your working tree, someone has an un-bumped submodule pointer somewhere and CI will be the source of truth.
+
 ## How to fix when it flags
 
-Renumber the offending migration in the repo with **fewer** migrations (auth, today) by adding 1 second to the timestamp:
+Renumber the migration on the side that has **not** been applied to any live deployment yet (typically the branch that has only touched `develop`, never a prod/staging DB). Bumping the timestamp by 1 second is enough:
 
 ```sh
 cd evo-auth-service-community

--- a/scripts/check_migration_collision.sh
+++ b/scripts/check_migration_collision.sh
@@ -28,6 +28,6 @@ if [[ -n "$collisions" ]]; then
   exit 1
 fi
 
-crm_count=$(echo "$crm_versions" | wc -l)
-auth_count=$(echo "$auth_versions" | wc -l)
+crm_count=$([[ -z "$crm_versions" ]] && echo 0 || echo "$crm_versions" | wc -l)
+auth_count=$([[ -z "$auth_versions" ]] && echo 0 || echo "$auth_versions" | wc -l)
 echo "No migration version collisions between CRM (${crm_count} versions) and auth (${auth_count} versions)."

--- a/scripts/check_migration_collision.sh
+++ b/scripts/check_migration_collision.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CRM_DIR="evo-ai-crm-community/db/migrate"
+AUTH_DIR="evo-auth-service-community/db/migrate"
+
+if [[ ! -d "$CRM_DIR" || ! -d "$AUTH_DIR" ]]; then
+  echo "ERROR: expected migration dirs not found. Run from umbrella root." >&2
+  exit 2
+fi
+
+crm_versions=$(ls "$CRM_DIR" | grep -E '^[0-9]{14}_' | sed -E 's/^([0-9]{14})_.*$/\1/' | sort -u)
+auth_versions=$(ls "$AUTH_DIR" | grep -E '^[0-9]{14}_' | sed -E 's/^([0-9]{14})_.*$/\1/' | sort -u)
+
+collisions=$(comm -12 <(echo "$crm_versions") <(echo "$auth_versions") || true)
+
+if [[ -n "$collisions" ]]; then
+  echo "Migration version collision(s) between CRM and auth:" >&2
+  while IFS= read -r v; do
+    crm_file=$(ls "$CRM_DIR" | grep "^${v}_" || true)
+    auth_file=$(ls "$AUTH_DIR" | grep "^${v}_" || true)
+    echo "  version=$v" >&2
+    echo "    CRM : $crm_file" >&2
+    echo "    auth: $auth_file" >&2
+  done <<< "$collisions"
+  echo "" >&2
+  echo "Renumber one side by 1 second (see scripts/README-migration-guard.md)." >&2
+  exit 1
+fi
+
+crm_count=$(echo "$crm_versions" | wc -l)
+auth_count=$(echo "$auth_versions" | wc -l)
+echo "No migration version collisions between CRM (${crm_count} versions) and auth (${auth_count} versions)."


### PR DESCRIPTION
Follow-up to #146 (merged as c8ab350). The migration collision guard is currently **red on develop** because the auth submodule pin lags behind the rename.

## Root cause

Umbrella HEAD (`c8ab350`) pins `evo-auth-service-community` at `3f185df` — pre-rename. That commit still contains `20260622120000_grant_rbac_split_permissions_to_existing_roles.rb`, colliding with CRM's `20260622120000_add_source_to_messages.rb` at `041a5ef`.

CI (`actions/checkout@v4` with `submodules: recursive`) reads the **pinned** SHAs, not any branch tip. The local smoke in #146 passed because the working tree had auth at `f1f4cee` (post-rename); CI does not.

## Empirical repro on develop

```sh
git submodule update --init evo-auth-service-community
./scripts/check_migration_collision.sh
# exit=1
# Migration version collision(s) between CRM and auth:
#   version=20260622120000
#     CRM : 20260622120000_add_source_to_messages.rb
#     auth: 20260622120000_grant_rbac_split_permissions_to_existing_roles.rb
```

## Fixes

- **Bump `evo-auth-service-community` → `f1f4cee`** (tip of evolution-foundation/evo-auth-service-community#55), which renamed the file to `20260622120001_...`. Guard now green.
- **Script hardening (`scripts/check_migration_collision.sh`)**: `echo \"\" | wc -l` returned 1; swap to `[[ -z ]] && echo 0 || wc -l` so the success message doesn't lie when a dir is empty.
- **README — new \"Reproducing CI behavior locally\" section**: documents that running the script against your working tree can lie if a submodule is checked out ahead of its pin. `git submodule update --init --recursive` first for CI-parity.
- **README — renumbering guidance rewritten**: \"repo with fewer migrations (auth, today)\" is a heuristic that ages badly. Replaced with the actual criterion: the side not yet applied to any live deployment.

## Dependency

- evolution-foundation/evo-auth-service-community#55 must stay open or merge — `f1f4cee` needs to remain reachable in that repo. Once #55 merges into auth `develop`, a small follow-up PR can retarget this pin to the merge commit for cleanliness (or wait — the pin remains valid either way).

## Test plan

- [x] `git submodule update --init evo-auth-service-community && ./scripts/check_migration_collision.sh` → exit 0, guard green with the new pin.
- [x] Empty-dir edge case reasoned: `_count` now reports 0 correctly.
- [ ] Reviewer confirms the new CI job passes on this PR.

## Linked Issue

- EVO-1911

## Summary by Sourcery

Add a CI guard to detect migration version collisions between CRM and auth and align the auth submodule and documentation around this workflow.

New Features:
- Introduce a migration collision guard script to detect overlapping migration version prefixes between CRM and auth.
- Add a CI job that runs the migration collision guard on pull requests to the umbrella repository.

Enhancements:
- Update the auth service submodule pointer to a commit that avoids a known migration version collision and keeps the umbrella in sync.

CI:
- Extend the main CI workflow with a dedicated job to run the migration collision guard using pinned submodule SHAs.

Documentation:
- Add documentation describing the migration collision guard, how to reproduce CI behavior locally, how to resolve flagged collisions, and related conventions and limitations.