### PR TITLE
fix(swarm): storage local, senha do processor e mídia no gateway (EVO-1966)

### DIFF
--- a/docker-compose.swarm.yaml
+++ b/docker-compose.swarm.yaml
@@ -120,16 +120,21 @@ services:
       - MFA_ISSUER=EvoCRM
       - SIDEKIQ_CONCURRENCY=10
 
-    ## 🗂️ Storage (S3 compatível) — opcional, preencha se for usar storage externo
-      - ACTIVE_STORAGE_SERVICE=s3_compatible
-      - STORAGE_BUCKET_NAME=evoaicrm   # Nome do seu bucket
-      - STORAGE_ACCESS_KEY_ID=         # Access key do seu S3
-      - STORAGE_SECRET_ACCESS_KEY=     # Secret key do seu S3
-      - STORAGE_REGION=auto
-      - STORAGE_ENDPOINT=https://      # Endpoint do seu S3. Ex.: https://xxxx.r2.cloudflarestorage.com
+    ## 🗂️ Storage — 'local' por padrão: mídia gravada em disco (volumes evocrm_storage / evoauth_storage).
+    ## Para usar S3/R2/MinIO externo, troque para s3_compatible e descomente/preencha as STORAGE_* abaixo.
+      - ACTIVE_STORAGE_SERVICE=local
+      - ACTIVE_STORAGE_URL=https://SUBDOMAIN_API   # URL publica p/ midia local (browser) = BACKEND_URL; gateway roteia /rails/active_storage -> CRM
+      # - ACTIVE_STORAGE_SERVICE=s3_compatible
+      # - STORAGE_BUCKET_NAME=meu-bucket
+      # - STORAGE_ACCESS_KEY_ID=
+      # - STORAGE_SECRET_ACCESS_KEY=
+      # - STORAGE_REGION=auto
+      # - STORAGE_ENDPOINT=https://xxxx.r2.cloudflarestorage.com
 
       - OAUTH_TOKEN_EXPIRES_IN=28800
 
+    volumes:
+      - evoauth_storage:/app/storage
     deploy:
       placement:
         constraints:
@@ -188,19 +193,24 @@ services:
       - MFA_ISSUER=EvoCRM
       - SIDEKIQ_CONCURRENCY=10
 
-    ## 🗂️ Storage (S3 compatível) — opcional, preencha se for usar storage externo
-      - ACTIVE_STORAGE_SERVICE=s3_compatible
-      - STORAGE_BUCKET_NAME=evoaicrm   # Nome do seu bucket
-      - STORAGE_ACCESS_KEY_ID=         # Access key do seu S3
-      - STORAGE_SECRET_ACCESS_KEY=     # Secret key do seu S3
-      - STORAGE_REGION=auto
-      - STORAGE_ENDPOINT=https://      # Endpoint do seu S3
+    ## 🗂️ Storage — 'local' por padrão: mídia gravada em disco (volumes evocrm_storage / evoauth_storage).
+    ## Para usar S3/R2/MinIO externo, troque para s3_compatible e descomente/preencha as STORAGE_* abaixo.
+      - ACTIVE_STORAGE_SERVICE=local
+      - ACTIVE_STORAGE_URL=https://SUBDOMAIN_API   # URL publica p/ midia local (browser) = BACKEND_URL; gateway roteia /rails/active_storage -> CRM
+      # - ACTIVE_STORAGE_SERVICE=s3_compatible
+      # - STORAGE_BUCKET_NAME=meu-bucket
+      # - STORAGE_ACCESS_KEY_ID=
+      # - STORAGE_SECRET_ACCESS_KEY=
+      # - STORAGE_REGION=auto
+      # - STORAGE_ENDPOINT=https://xxxx.r2.cloudflarestorage.com
 
       - OAUTH_TOKEN_EXPIRES_IN=28800
 
     healthcheck:
       disable: true
 
+    volumes:
+      - evoauth_storage:/app/storage
     deploy:
       placement:
         constraints:
@@ -260,14 +270,19 @@ services:
       - BOT_RUNTIME_SECRET=     # Segredo do bot runtime (o mesmo em crm, crm_sidekiq e bot_runtime). Ex.: "openssl rand -hex 32"
       - BOT_RUNTIME_POSTBACK_BASE_URL=http://evocrm_crm:3000
 
-    ## 🗂️ Storage (S3 compatível) — opcional, preencha se for usar storage externo
-      - ACTIVE_STORAGE_SERVICE=s3_compatible
-      - STORAGE_BUCKET_NAME=evoaicrm   # Nome do seu bucket
-      - STORAGE_ACCESS_KEY_ID=         # Access key do seu S3
-      - STORAGE_SECRET_ACCESS_KEY=     # Secret key do seu S3
-      - STORAGE_REGION=auto
-      - STORAGE_ENDPOINT=https://      # Endpoint do seu S3
+    ## 🗂️ Storage — 'local' por padrão: mídia gravada em disco (volumes evocrm_storage / evoauth_storage).
+    ## Para usar S3/R2/MinIO externo, troque para s3_compatible e descomente/preencha as STORAGE_* abaixo.
+      - ACTIVE_STORAGE_SERVICE=local
+      - ACTIVE_STORAGE_URL=https://SUBDOMAIN_API   # URL publica p/ midia local (browser) = BACKEND_URL; gateway roteia /rails/active_storage -> CRM
+      # - ACTIVE_STORAGE_SERVICE=s3_compatible
+      # - STORAGE_BUCKET_NAME=meu-bucket
+      # - STORAGE_ACCESS_KEY_ID=
+      # - STORAGE_SECRET_ACCESS_KEY=
+      # - STORAGE_REGION=auto
+      # - STORAGE_ENDPOINT=https://xxxx.r2.cloudflarestorage.com
 
+    volumes:
+      - evocrm_storage:/app/storage
     deploy:
       placement:
         constraints:
@@ -316,14 +331,19 @@ services:
       - BOT_RUNTIME_SECRET=     # Mesmo valor de BOT_RUNTIME_SECRET usado no evocrm_crm e bot_runtime
       - BOT_RUNTIME_POSTBACK_BASE_URL=http://evocrm_crm:3000
 
-    ## 🗂️ Storage (S3 compatível) — opcional, preencha se for usar storage externo
-      - ACTIVE_STORAGE_SERVICE=s3_compatible
-      - STORAGE_BUCKET_NAME=evoaicrm   # Nome do seu bucket
-      - STORAGE_ACCESS_KEY_ID=         # Access key do seu S3
-      - STORAGE_SECRET_ACCESS_KEY=     # Secret key do seu S3
-      - STORAGE_REGION=auto
-      - STORAGE_ENDPOINT=https://      # Endpoint do seu S3
+    ## 🗂️ Storage — 'local' por padrão: mídia gravada em disco (volumes evocrm_storage / evoauth_storage).
+    ## Para usar S3/R2/MinIO externo, troque para s3_compatible e descomente/preencha as STORAGE_* abaixo.
+      - ACTIVE_STORAGE_SERVICE=local
+      - ACTIVE_STORAGE_URL=https://SUBDOMAIN_API   # URL publica p/ midia local (browser) = BACKEND_URL; gateway roteia /rails/active_storage -> CRM
+      # - ACTIVE_STORAGE_SERVICE=s3_compatible
+      # - STORAGE_BUCKET_NAME=meu-bucket
+      # - STORAGE_ACCESS_KEY_ID=
+      # - STORAGE_SECRET_ACCESS_KEY=
+      # - STORAGE_REGION=auto
+      # - STORAGE_ENDPOINT=https://xxxx.r2.cloudflarestorage.com
 
+    volumes:
+      - evocrm_storage:/app/storage
     deploy:
       placement:
         constraints:
@@ -385,8 +405,9 @@ services:
       - evonet ## Nome da rede interna
 
     environment:
-    ## 🗄️ PostgreSQL — troque SENHA pela mesma senha do Postgres usada nos demais serviços
-      - POSTGRES_CONNECTION_STRING=postgresql://postgres:SENHA@pgvector:5432/evocrm?sslmode=disable
+    ## 🗄️ PostgreSQL — a senha está DENTRO da URL. Substitua <POSTGRES_PASSWORD> pela
+    ## mesma senha do Postgres usada nos demais serviços (o app lê só esta connection string).
+      - POSTGRES_CONNECTION_STRING=postgresql://postgres:<POSTGRES_PASSWORD>@pgvector:5432/evocrm?sslmode=disable
 
     ## 🧊 Redis
       - REDIS_HOST=evocrm_redis
@@ -524,6 +545,8 @@ volumes:
   evocrm_redis:
     external: true
     name: evocrm_redis
+  evocrm_storage:
+  evoauth_storage:
 
 networks:
   evonet: ## Nome da rede interna

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -397,7 +397,9 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        client_max_body_size 10M;
+        # WhatsApp media chega base64 inline no webhook (Evolution) — 10M rejeitava
+        # documentos/PDF com 413. Alinha com o limite de 100M do resto do gateway (EVO-1966).
+        client_max_body_size 100M;
     }
 
     # =============================================================================


### PR DESCRIPTION
## O que

Três correções no swarm/gateway que bloqueavam o uso **out-of-the-box** do CRM self-hosted. Todas **validadas subindo o `docker-compose.swarm.yaml` num ambiente limpo** (deploy real como self-hoster, imagens publicadas) — não só por leitura.

### 1. Storage de mídia quebrado sem S3 — `docker-compose.swarm.yaml`
O swarm cravava `ACTIVE_STORAGE_SERVICE=s3_compatible` com bucket setado mas **sem credenciais/endpoint** → mídia não carrega sem um S3 externo. Correção:
- `ACTIVE_STORAGE_SERVICE=local` por padrão nos 4 serviços Rails (auth, auth_sidekiq, crm, crm_sidekiq);
- volumes persistentes compartilhados `evocrm_storage`/`evoauth_storage` em `/app/storage`;
- `ACTIVE_STORAGE_URL` (= `BACKEND_URL`) — sem ele a mídia local não renderiza (grey blob);
- S3 vira opt-in comentado.

> Complementa o **EVO-1961**: aquela PR corrigiu o default do `.env.example` (dev) e um fallback de código, mas **não cobre o swarm** — o fallback só dispara com `STORAGE_BUCKET_NAME` vazio, e o swarm setava `evoaicrm`.

### 2. Processor não autenticava no Postgres — `docker-compose.swarm.yaml`
A senha do processor vinha embutida na `POSTGRES_CONNECTION_STRING` com o placeholder literal `SENHA` — que ninguém preenche seguindo o header (todos os outros serviços usam `POSTGRES_PASSWORD=`). Resultado: processor em crash-loop. Trocado por `<POSTGRES_PASSWORD>`, discoverable.

### 3. PDF/documento dá 413 no gateway — `nginx/default.conf.template`
O location `/webhooks` tinha `client_max_body_size 10M`. A Evolution API posta mídia **base64 inline** no webhook → PDFs estouram 10M → **413** (imagem menor passava). Alinhado aos 100M do resto do gateway.

## Validação

Deploy completo no swarm (11 serviços) + Evolution API. Mensagem, imagem e PDF chegando no CRM com **storage local** funcionando (mídia grava em disco e renderiza). Os três sintomas foram reproduzidos e corrigidos ao vivo.

## Follow-up

O fix #3 é no template do nginx → só entra em produção quando a imagem `evo-crm-gateway` for **rebuildada**. Os #1 e #2 valem já no próximo `docker stack deploy`.
