### PR TITLE
fix(compose): RUN_MIGRATIONS gate for sidekiqs/auth-web (EVO-1999)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,8 +71,8 @@ services:
       RAILS_ENV: ${RAILS_ENV:-development}
       REDIS_URL: redis://:${REDIS_PASSWORD:-evoai_redis_pass}@redis:6379/1
       POSTGRES_HOST: postgres
-      # EVO-1999: o command deste serviço já roda db:create && db:migrate, e a
-      # imagem migra no boot (entrypoint). RUN_MIGRATIONS=false evita duplicar.
+      # EVO-1999: this service's command already runs db:create && db:migrate, and
+      # the image migrates on boot (entrypoint). RUN_MIGRATIONS=false avoids doubling.
       RUN_MIGRATIONS: "false"
     volumes:
       - ./evo-auth-service-community/storage:/rails/storage
@@ -99,7 +99,7 @@ services:
       RAILS_ENV: ${RAILS_ENV:-development}
       REDIS_URL: redis://:${REDIS_PASSWORD:-evoai_redis_pass}@redis:6379/1
       POSTGRES_HOST: postgres
-      # EVO-1999: sidekiq não deve rodar migrations (o serviço web já cobre).
+      # EVO-1999: sidekiq must not run migrations (the web service already covers it).
       RUN_MIGRATIONS: "false"
     depends_on:
       postgres:
@@ -178,7 +178,7 @@ services:
       BOT_RUNTIME_URL: http://evo-bot-runtime:8080
       BOT_RUNTIME_SECRET: ${BOT_RUNTIME_SECRET:-evo-bot-runtime-dev-secret}
       BOT_RUNTIME_POSTBACK_BASE_URL: http://evo-crm:3000
-      # EVO-1999: sidekiq não deve preparar o banco (o web já cobre via db:prepare).
+      # EVO-1999: sidekiq must not prepare the database (the web covers it via db:prepare).
       RUN_MIGRATIONS: "false"
     volumes:
       - ./evo-ai-crm-community:/app:delegated
@@ -195,7 +195,8 @@ services:
     # Disable inherited HTTP healthcheck — Sidekiq has no web server.
     healthcheck:
       disable: true
-    entrypoint: docker/entrypoints/rails.sh
+    # LOW (review): no explicit entrypoint — the image ENTRYPOINT is already
+    # docker/entrypoints/rails.sh (EVO-1999); RUN_MIGRATIONS=false skips db:prepare.
     command: ["bundle", "exec", "sidekiq", "-C", "config/sidekiq.yml"]
 
   # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       RAILS_ENV: ${RAILS_ENV:-development}
       REDIS_URL: redis://:${REDIS_PASSWORD:-evoai_redis_pass}@redis:6379/1
       POSTGRES_HOST: postgres
+      # EVO-1999: o command deste serviço já roda db:create && db:migrate, e a
+      # imagem migra no boot (entrypoint). RUN_MIGRATIONS=false evita duplicar.
+      RUN_MIGRATIONS: "false"
     volumes:
       - ./evo-auth-service-community/storage:/rails/storage
     depends_on:
@@ -96,6 +99,8 @@ services:
       RAILS_ENV: ${RAILS_ENV:-development}
       REDIS_URL: redis://:${REDIS_PASSWORD:-evoai_redis_pass}@redis:6379/1
       POSTGRES_HOST: postgres
+      # EVO-1999: sidekiq não deve rodar migrations (o serviço web já cobre).
+      RUN_MIGRATIONS: "false"
     depends_on:
       postgres:
         condition: service_healthy
@@ -173,6 +178,8 @@ services:
       BOT_RUNTIME_URL: http://evo-bot-runtime:8080
       BOT_RUNTIME_SECRET: ${BOT_RUNTIME_SECRET:-evo-bot-runtime-dev-secret}
       BOT_RUNTIME_POSTBACK_BASE_URL: http://evo-crm:3000
+      # EVO-1999: sidekiq não deve preparar o banco (o web já cobre via db:prepare).
+      RUN_MIGRATIONS: "false"
     volumes:
       - ./evo-ai-crm-community:/app:delegated
       - crm_bundle:/usr/local/bundle


### PR DESCRIPTION
## Contexto
Complemento da **EVO-1999** no `docker-compose.yml` do monorepo. As PRs de imagem (crm `#197`, auth `#57`) fazem a imagem **migrar no boot** via gate `RUN_MIGRATIONS` (default `true` = fail-safe). Isso exige desativar o gate nos serviços que **não** devem preparar o banco — senão eles migram em duplicado no boot.

## Mudança
`RUN_MIGRATIONS: "false"` em 3 serviços:
- **`evo-auth` (web):** o `command` já roda `db:create && db:migrate`; o `false` evita o entrypoint duplicar.
- **`evo-auth-sidekiq` / `evo-crm-sidekiq`:** sidekiq não deve migrar/preparar (o web já cobre). Sem isto, o `evo-crm-sidekiq` (que tem `entrypoint: rails.sh`) rodaria `db:prepare` no boot.

`evo-crm` (web) mantém o default `true` (migra via `rails.sh`). Advisory lock do Postgres protege caso mais de um serviço tente migrar.

## Por que uma PR separada
As PRs `#197`/`#57` vivem nos submódulos (imagens). Esta config de orquestração vive no compose do monorepo — sem ela, o critério de aceite "sidekiq NÃO roda migrate" não fica garantido no `develop`.

## Testes
- [x] `docker compose config` valida (YAML ok).
- [x] `evo-crm-sidekiq` sobe sem preparar o banco (RUN_MIGRATIONS=false respeitado pelo `rails.sh`).
- [x] `evo-crm` (web) continua migrando no boot (default true).

Parte de EVO-1999

## Summary by Sourcery

Configure RUN_MIGRATIONS gates in docker-compose to prevent duplicate database migrations and ensure sidekiq services do not run migrations.

Bug Fixes:
- Disable RUN_MIGRATIONS for evo-auth web to avoid redundant migrations between the container command and image entrypoint.
- Disable RUN_MIGRATIONS for evo-auth-sidekiq and evo-crm-sidekiq so these worker services no longer prepare or migrate the database on boot.