### PR TITLE
ci: guard de colisão de version de migration CRM×auth — follow-up EVO-1911 (EVO-2090)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# EVO-2090: shell scripts sempre LF (CI roda em Linux; evita CRLF de commits Windows)
+*.sh text eol=lf

--- a/.github/scripts/check-migration-version-collisions.sh
+++ b/.github/scripts/check-migration-version-collisions.sh
@@ -29,7 +29,9 @@ for d in "$CRM_DIR" "$AUTH_DIR"; do
 done
 
 # Extrai a version (14 dígitos iniciais) de cada arquivo de migration, únicas e ordenadas.
-versions() { ls "$1" 2>/dev/null | grep -oE '^[0-9]{14}' | sort -u; }
+# `|| true`: grep sai 1 quando o dir não tem nenhum arquivo de 14 dígitos, o que sob
+# `pipefail` abortaria a atribuição `crm_versions="$(...)"` com falha espúria.
+versions() { ls "$1" 2>/dev/null | grep -oE '^[0-9]{14}' | sort -u || true; }
 
 crm_versions="$(versions "$CRM_DIR")"
 auth_versions="$(versions "$AUTH_DIR")"

--- a/.github/scripts/check-migration-version-collisions.sh
+++ b/.github/scripts/check-migration-version-collisions.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# EVO-2090 (follow-up EVO-1911) — Guard de colisão de version de migration.
+#
+# evo-ai-crm-community e evo-auth-service-community compartilham o mesmo banco e a
+# mesma tabela `schema_migrations`. O Rails registra cada version (timestamp de 14
+# dígitos) nessa tabela; se um serviço registra uma version, uma migration do OUTRO
+# serviço com a MESMA version é considerada "já executada" e pulada para sempre ->
+# a DDL dela nunca roda -> coluna/tabela ausente -> o app quebra no boot
+# (ex.: `messages.source` -> "Undeclared attribute type for enum 'source'").
+#
+# Este script falha (exit 1) se os dois serviços tiverem qualquer version em comum
+# em db/migrate. Rodável no CI (submódulos checkout) e localmente.
+#
+# Uso:
+#   check-migration-version-collisions.sh [CRM_MIGRATE_DIR] [AUTH_MIGRATE_DIR]
+# Defaults assumem a raiz do monorepo (submódulos).
+
+set -euo pipefail
+
+CRM_DIR="${1:-evo-ai-crm-community/db/migrate}"
+AUTH_DIR="${2:-evo-auth-service-community/db/migrate}"
+
+for d in "$CRM_DIR" "$AUTH_DIR"; do
+  if [ ! -d "$d" ]; then
+    echo "::error::diretório de migrations não encontrado: $d (submódulos inicializados?)"
+    exit 2
+  fi
+done
+
+# Extrai a version (14 dígitos iniciais) de cada arquivo de migration, únicas e ordenadas.
+versions() { ls "$1" 2>/dev/null | grep -oE '^[0-9]{14}' | sort -u; }
+
+crm_versions="$(versions "$CRM_DIR")"
+auth_versions="$(versions "$AUTH_DIR")"
+
+dup="$(comm -12 <(printf '%s\n' "$crm_versions") <(printf '%s\n' "$auth_versions"))"
+
+if [ -n "$dup" ]; then
+  echo "::error::Colisão de version de migration entre CRM e auth (schema_migrations compartilhado):"
+  while IFS= read -r v; do
+    [ -z "$v" ] && continue
+    echo "  version $v"
+    echo "    CRM:  $(ls "$CRM_DIR"  | grep "^$v" || echo '(?)')"
+    echo "    AUTH: $(ls "$AUTH_DIR" | grep "^$v" || echo '(?)')"
+  done <<< "$dup"
+  echo ""
+  echo "Renomeie uma das migrations para um timestamp livre (segundos distintos por"
+  echo "serviço) — ver convenção em CONTRIBUTING. Nunca reutilize a mesma version"
+  echo "entre CRM e auth enquanto compartilharem schema_migrations."
+  exit 1
+fi
+
+crm_count="$(printf '%s\n' "$crm_versions" | grep -c . || true)"
+auth_count="$(printf '%s\n' "$auth_versions" | grep -c . || true)"
+echo "OK: nenhuma version compartilhada entre CRM ($crm_count) e auth ($auth_count)."

--- a/.github/workflows/migration-version-collision-guard.yml
+++ b/.github/workflows/migration-version-collision-guard.yml
@@ -1,0 +1,28 @@
+name: Migration version collision guard
+
+# EVO-2090 (follow-up EVO-1911): evo-ai-crm-community e evo-auth-service-community
+# compartilham a mesma tabela `schema_migrations`. Uma version reusada entre os
+# dois faz o Rails pular a migration do serviço que rodou depois -> DDL/coluna
+# ausente -> boot quebra (ex.: messages.source). Este guard falha o CI se houver
+# qualquer timestamp de migration em comum entre os dois submódulos.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  migration-collision:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (com submódulos)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checar colisão de version de migration (CRM x auth)
+        run: bash .github/scripts/check-migration-version-collisions.sh

--- a/.github/workflows/migration-version-collision-guard.yml
+++ b/.github/workflows/migration-version-collision-guard.yml
@@ -1,10 +1,15 @@
 name: Migration version collision guard
 
-# EVO-2090 (follow-up EVO-1911): evo-ai-crm-community e evo-auth-service-community
-# compartilham a mesma tabela `schema_migrations`. Uma version reusada entre os
-# dois faz o Rails pular a migration do serviço que rodou depois -> DDL/coluna
-# ausente -> boot quebra (ex.: messages.source). Este guard falha o CI se houver
-# qualquer timestamp de migration em comum entre os dois submódulos.
+# EVO-2090: evo-ai-crm-community e evo-auth-service-community compartilham UMA
+# tabela `schema_migrations` (mesmo banco). Uma version reusada faz o Rails pular
+# a migration do segundo app -> DDL ausente -> boot quebra (messages.source,
+# EVO-1911).
+#
+# A prevenção PRIMÁRIA vive no CI de CADA repo como regra de PARIDADE de version
+# (auth = ímpar, CRM = par -> espaços disjuntos, colisão impossível por
+# construção). Este guard do monorepo é o BACKSTOP (cinto-e-suspensório): falha se
+# os dois submódulos fixados compartilharem qualquer version (ex.: uma
+# grandfathered/pré-cutoff, ou se um check de paridade por-repo for burlado).
 
 on:
   pull_request:
@@ -23,6 +28,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Self-test do guard (fixtures)
+        run: |
+          set -euo pipefail
+          guard=.github/scripts/check-migration-version-collisions.sh
+          tmp="$(mktemp -d)"; mkdir -p "$tmp/crm" "$tmp/auth"
+          # (1) sem version compartilhada -> DEVE passar (exit 0)
+          : > "$tmp/crm/20200101000000_a.rb"
+          : > "$tmp/auth/20200101000001_b.rb"
+          bash "$guard" "$tmp/crm" "$tmp/auth"
+          # (2) version compartilhada -> DEVE falhar (exit 1)
+          : > "$tmp/auth/20200101000000_c.rb"
+          if bash "$guard" "$tmp/crm" "$tmp/auth"; then
+            echo "::error::self-test FALHOU — o guard não detectou a colisão injetada"
+            exit 1
+          fi
+          echo "self-test OK: passa em input limpo e falha na colisão"
 
       - name: Checar colisão de version de migration (CRM x auth)
         run: bash .github/scripts/check-migration-version-collisions.sh


### PR DESCRIPTION
## Contexto — EVO-2090 (follow-up EVO-1911)

`evo-ai-crm-community` e `evo-auth-service-community` são apps separados que apontam pro **mesmo banco** e compartilham **uma** tabela `schema_migrations`. Uma version (timestamp de 14 dígitos) reusada entre os dois faz o Rails **pular** a migration do segundo app → DDL ausente → boot quebra (`messages.source`).

## Solução em duas camadas

**Camada 1 — Prevenção primária (nos repos, por PARIDADE):** colisão **impossível por construção**, sem banco novo, sem tabela nova, sem cross-repo.
- **auth = versions ÍMPARES** · **CRM = versions PARES** (espaços disjuntos → nunca colidem).
- Cada repo valida a **si mesmo** no próprio CI (spec RSpec), pegando a migration ruim **no PR que a introduz**. Migrations antigas são grandfathered por um cutoff (`20260713000000`).
- PRs: auth `evo-auth-service-community#64` · CRM `evo-ai-crm-community#224`.

**Camada 2 — Backstop (esta PR, no monorepo):** cinto-e-suspensório. Compara os `db/migrate` dos dois submódulos fixados e falha se compartilharem qualquer version (pega uma grandfathered/pré-cutoff, ou se um check de paridade for burlado).

## O que esta PR entrega (backstop, endurecido pós-review)

- `.github/scripts/check-migration-version-collisions.sh` — compara as versions dos dois submódulos, sai **1** listando as colidentes.
- `.github/workflows/migration-version-collision-guard.yml` — roda em PR/push (`main`/`develop`) com `submodules: recursive`, **+ self-test** (fixtures: caso limpo → exit 0; colisão injetada → exit 1) para o guard não passar silenciosamente se sua lógica quebrar.
- `.gitattributes` — `*.sh text eol=lf` (evita CRLF de commit Windows quebrar o bash do runner).

## Validação (executada localmente)
```
# submódulos atuais (sem colisão): OK: nenhuma version compartilhada CRM (79) x auth (23)  -> exit 0
# colisão injetada (20200101000000 nos dois):                                              -> exit 1
# self-test (mesma lógica do CI): caso limpo passa, caso colisão falha  -> OK
```

## Por que isto fecha os gaps do review
- **Camada errada** → resolvido: a prevenção **primária** agora está no CI de cada repo (paridade), pegando no PR de origem; o monorepo vira backstop.
- **Sem self-test** → resolvido: o workflow testa o próprio guard.
- **CRLF** → resolvido: `.gitattributes` força LF.

Refs **EVO-2090**.
