### PR TITLE
fix(gateway): route agent OAuth integration paths to the processor

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -271,6 +271,23 @@ server {
     # =============================================================================
     # EvoAI Core Service Routes
     # =============================================================================
+    # Agent-specific integration endpoints
+    location ~ ^/api/v1/agents/[^/]+/integrations/ {
+        proxy_pass $processor_service$request_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization $http_authorization;
+
+        proxy_set_header api_access_token $http_api_access_token;
+        proxy_cookie_path / /;
+        proxy_set_header Cookie $http_cookie;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
     location ~ ^/api/v1/(agents|folders|mcp-servers|custom-mcp-servers|custom-tools) {
         proxy_pass $evoai_service$request_uri;
         proxy_set_header Host $host;
@@ -320,23 +337,6 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Authorization $http_authorization;
         proxy_set_header X-Api-Key $http_x_api_key;
-
-        proxy_set_header api_access_token $http_api_access_token;
-        proxy_cookie_path / /;
-        proxy_set_header Cookie $http_cookie;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
-
-    # Agent-specific integration endpoints
-    location ~ ^/api/v1/agents/[^/]+/integrations {
-        proxy_pass $processor_service$request_uri;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Authorization $http_authorization;
 
         proxy_set_header api_access_token $http_api_access_token;
         proxy_cookie_path / /;


### PR DESCRIPTION
## Gateway: rotear as integrações OAuth por-agente pro processor

**Bug:** o nginx casa `location` regex **na ordem de definição**. O bloco amplo `^/api/v1/(agents|folders|mcp-servers|...)` (→ evoai core) vinha **antes** do bloco `^/api/v1/agents/[^/]+/integrations` (→ processor), então sombreava ele. Toda chamada de integração OAuth por-agente (google-calendar/sheets: authorization, callback, calendars, PUT de config) ia pro **core**, que não implementa → **404**.

Isso quebrava o connect de Google Calendar/Sheets no agente de ponta a ponta (descoberto ao habilitar essas integrações; ver PRs do front/processor relacionados).

**Fix:**
- Mover o bloco de integrations pra **antes** do bloco do core.
- Escopar pra `^/api/v1/agents/[^/]+/integrations/` (tem que ter um segmento de provider depois), pra que o **`GET /api/v1/agents/:id/integrations`** (a lista, que carrega o estado "conectado") continue caindo no **core** (que é dono da lista persistida), enquanto os paths com provider vão pro **processor**.

Já aplicado como hotfix efêmero no staging e validado (calendar conecta, lista mostra ATIVO, save funciona). Este PR torna permanente no template do gateway (`nginx/default.conf.template`, publicado por `gateway-publish.yml`).

## Summary by Sourcery

Route agent-specific OAuth integration requests through the processor instead of the core service by adjusting Nginx location matching order and path scope in the gateway configuration.

Bug Fixes:
- Ensure agent OAuth integration endpoints (e.g., Google Calendar/Sheets authorization, callbacks, and configuration) are correctly routed to the processor to prevent 404 responses from the core service.

Build:
- Update the Nginx default configuration template in the gateway to permanently apply the corrected routing for agent OAuth integration paths.

CI:
- Keep the gateway publish workflow referencing the updated Nginx template so the routing fix is propagated in deployments.

Deployment:
- Make the previously hotfixed agent OAuth routing behavior permanent in the gateway configuration used across environments.