### PR TITLE
chore(EVO-2178): ship MEDIA_HOST_ALLOWLIST on every deploy surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -309,3 +309,8 @@ VITE_TINYMCE_API_KEY=no-api-key
 
 # # OpenAI (for AI-powered features)
 # OPENAI_API_KEY=
+
+# Host(s) allowed to serve incoming media to the AI agent, comma-separated,
+# no scheme or port. Must match the host of BACKEND_URL above (that is what
+# signs the attachment URLs); without it the agent receives no media.
+MEDIA_HOST_ALLOWLIST=localhost

--- a/.env.swarm.example
+++ b/.env.swarm.example
@@ -85,3 +85,8 @@ MFA_ISSUER=EvoCRM
 SIDEKIQ_CONCURRENCY=10
 ACTIVE_STORAGE_SERVICE=local
 ORGANIZATION_NAME=Evo CRM
+
+# Host(s) que servem a midia recebida ao agente, separados por virgula, sem
+# esquema nem porta. Deve casar com o host do BACKEND_URL (quem assina a URL
+# do anexo); sem isso o agente nao recebe midia. Ex.: crm.seudominio.com
+MEDIA_HOST_ALLOWLIST=

--- a/docker-compose.swarm.yaml
+++ b/docker-compose.swarm.yaml
@@ -488,6 +488,9 @@ services:
       - AI_PROCESSOR_URL=http://evocrm_processor:8000
       - BOT_RUNTIME_SECRET=     # Mesmo valor de BOT_RUNTIME_SECRET usado no evocrm_crm e evocrm_crm_sidekiq
       - AI_CALL_TIMEOUT_SECONDS=30
+      - MEDIA_HOST_ALLOWLIST=   # Host(s) que servem a midia recebida, separados por virgula, sem esquema nem porta.
+                                # Use o host do BACKEND_URL do CRM (o que assina a URL do anexo); sem isso o agente nao recebe midia.
+                                # Ex.: "crm.seudominio.com".
 
     deploy:
       placement:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -288,6 +288,10 @@ services:
       REDIS_URL: redis://:${REDIS_PASSWORD:-evoai_redis_pass}@redis:6379
       AI_PROCESSOR_URL: http://evo-processor:8000
       BOT_RUNTIME_SECRET: ${BOT_RUNTIME_SECRET:-evo-bot-runtime-dev-secret}
+      # Hosts allowed to serve incoming media. Must cover the host the CRM signs
+      # attachment URLs with (ACTIVE_STORAGE_URL, or BACKEND_URL when unset), or
+      # the agent receives no media at all.
+      MEDIA_HOST_ALLOWLIST: ${MEDIA_HOST_ALLOWLIST:-localhost}
     depends_on:
       redis:
         condition: service_healthy

--- a/internal/review/docker-compose.yml
+++ b/internal/review/docker-compose.yml
@@ -299,6 +299,9 @@ services:
       AI_PROCESSOR_URL: http://evo_processor:8000
       BOT_RUNTIME_SECRET: evo-bot-runtime-dev-secret
       AI_CALL_TIMEOUT_SECONDS: 30
+      # Hosts allowed to serve incoming media; without this no attachment is
+      # fetched. Covers both the host BACKEND_URL uses and the compose alias.
+      MEDIA_HOST_ALLOWLIST: localhost,evo_crm
     depends_on:
       evo_redis:
         condition: service_healthy


### PR DESCRIPTION
Companion to evolution-foundation/evo-bot-runtime#7 — they should land together.

The bot runtime validates the host of an incoming attachment before fetching it, and reads the authorized hosts from `MEDIA_HOST_ALLOWLIST` **only** (an allowlist taken from the event would be chosen by whoever sent the event). Unset means no attachment is fetched, so the variable has to travel with the service or media silently stops reaching the agent.

Set it to the host that signs the attachment URLs: `ACTIVE_STORAGE_URL` when present, otherwise `BACKEND_URL`. Add the storage host as well when ActiveStorage runs in redirect mode (presigned S3/MinIO links), or the CDN host when one fronts the CRM.

Wired into:

- `docker-compose.yml` — `${MEDIA_HOST_ALLOWLIST:-localhost}`, matching the `BACKEND_URL` in `.env.example`
- `internal/review/docker-compose.yml` — `localhost,evo_crm`
- `docker-compose.swarm.yaml` — left blank next to the instructions, like the other per-deployment values there
- `.env.example` and `.env.swarm.example`

No submodule pointers are touched.

Part of EVO-2178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
