### PR TITLE
docs(readme): correct "no super-admin" in the monorepo README (CRM-180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This repository is the umbrella of the CRM Community family: it orchestrates the
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs — README role model corrected (CRM-180)** — the "Design principles" section claimed *"No super-admin"* and a closed `account_owner` + `agent` hierarchy with "no intermediate roles". Both were false: `evo-auth-service-community` seeds a third role, `super_admin` (the only holder of `installation_configs.manage`), and `account_owner` holds `roles.create`, so custom roles exist at runtime. Replaced by a **Roles** subsection that states the real model, that `super_admin` has no single-holder guarantee (audit `user_roles` instead of assuming one installation owner), and that `Role::ADMIN_ROLE_KEYS` is an admin-bypass allowlist rather than the role model.
+
 ## [v1.0.0] - 2026-07-15
 
 **The first stable release of the CRM Community family.** v1.0.0 promotes `v1.0.0-rc7` to GA after a focused stabilization/hardening pass — no new features of size; the window is bug fixes, security hardening, configuration-resolution corrections, multi-tenant/RLS wiring, and a frontend UI-redesign wave. ~135 commits across the family (CRM 43, processor 37, frontend 36, auth 11 net-new, core 8; `evo-bot-runtime` and `evo-flow-community` are alignment-only re-tags with zero delta). **No new database migrations in any service.**

--- a/README.md
+++ b/README.md
@@ -86,10 +86,27 @@ The Evo CRM Community platform is composed of 6 independent services:
 ### Design principles (Community Edition)
 
 - **Single-tenant** — one account, no multi-tenancy overhead
-- **Installation owner** — a single `super_admin` (created by the setup wizard) holds installation-level configuration (SMTP, Storage, OpenAI, etc.); all other configuration is via seed data and environment variables
 - **No billing / plans** — all limits removed, features unlocked by default
-- **Role hierarchy**: `account_owner` + `agent`, plus the single installation-owner `super_admin` — no intermediate roles (see the `evo-auth-service-community` RBAC seed and `Role::ADMIN_ROLE_KEYS` for the authoritative role model)
+- **Configuration via seed data and environment variables** — with one exception: installation-level settings (SMTP, Storage, Social Login, OpenAI, Channels, Inbound Email, Frontend Runtime) live in the database, behind `installation_configs.manage`
+- **Role hierarchy** — three seeded roles (`agent`, `account_owner`, `super_admin`), plus any custom role created at runtime — see [Roles](#roles)
 - **Account resolution** via token — no `account-id` header required between services
+
+#### Roles
+
+`db/seeds/rbac.rb` in [`evo-auth-service-community`](./evo-auth-service-community) is the authoritative role model. It seeds three roles:
+
+| Role | Scope | Permissions |
+|---|---|---|
+| `agent` | account | Attendance only — conversations, contacts, pipeline cards. Sees only the inboxes it is a member of |
+| `account_owner` | account | The whole catalog except `accounts.stats` and `installation_configs.manage` |
+| `super_admin` | installation | The whole catalog, including `installation_configs.manage` — the only role that renders Admin Settings and reaches `/api/v1/installation_configs/**` |
+
+Two facts a security review needs, because neither is enforced by the code:
+
+- **`super_admin` has no single-holder guarantee.** The setup wizard grants it to the user it creates, and the `PromoteFirstUserToSuperAdmin` migration grants it to the oldest user of an already-bootstrapped installation. Nothing prevents it being assigned to more — audit `user_roles` for the `super_admin` role key instead of assuming one installation owner.
+- **The seeded three are not the whole set.** `account_owner` holds `roles.create` and `roles.bulk_update_permissions`, so custom roles with arbitrary permission sets can be created at runtime via `POST /api/v1/roles`.
+
+`Role::ADMIN_ROLE_KEYS` (defined in `evo-ai-crm-community`, mirrored in auth and the frontend) is an admin-bypass allowlist, not the role model: it also names legacy `administrator`/`admin` keys the seed never creates, and the three copies disagree.
 
 ### Companion services (independent versioning)
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ The Evo CRM Community platform is composed of 6 independent services:
 ### Design principles (Community Edition)
 
 - **Single-tenant** — one account, no multi-tenancy overhead
-- **No super-admin** — all configuration via seed data and environment variables
+- **Installation owner** — a single `super_admin` (created by the setup wizard) holds installation-level configuration (SMTP, Storage, OpenAI, etc.); all other configuration is via seed data and environment variables
 - **No billing / plans** — all limits removed, features unlocked by default
-- **Role hierarchy**: `account_owner` and `agent` — no intermediate roles
+- **Role hierarchy**: `account_owner` + `agent`, plus the single installation-owner `super_admin` — no intermediate roles (see the `evo-auth-service-community` RBAC seed and `Role::ADMIN_ROLE_KEYS` for the authoritative role model)
 - **Account resolution** via token — no `account-id` header required between services
 
 ### Companion services (independent versioning)


### PR DESCRIPTION
## CRM-180 — o README do monorepo afirma "no super-admin", mas o papel existe

A seção **Design principles (Community Edition)** dizia:
- *"No super-admin — all configuration via seed data and environment variables"*
- *"Role hierarchy: `account_owner` and `agent` — no intermediate roles"*

As duas afirmações eram falsas.

**O papel existe.** `evo-auth-service-community db/seeds/rbac.rb` semeia `super_admin` com o catálogo inteiro, incluindo `installation_configs.manage` — a única permissão retirada do `account_owner`, e a única que renderiza o Admin Settings e alcança `/api/v1/installation_configs/**`.

**E não há garantia de titular único.** `SetupBootstrapService#assign_global_role` concede o papel ao usuário do bootstrap, e a migration `PromoteFirstUserToSuperAdmin` o concede ao usuário mais antigo de instalações já bootstrapadas (prod não roda `db:seed`). `UserRole` valida apenas `uniqueness: { scope: :role_id }` sobre `user_id` — "exatamente um" é intenção, não invariante. Foi essa falsa segurança que escondeu **5 `super_admin`** numa auditoria de cliente.

**E os três papéis semeados não são o conjunto todo.** `account_owner` recebe `roles.create` e `roles.bulk_update_permissions` (`resource_actions_config.rb:68-79`; rotas em `config/routes.rb:156-164`), então papéis customizados são criáveis em runtime via `POST /api/v1/roles`. "No intermediate roles" também é falso.

## O que este PR entrega

Substitui os dois bullets por uma subseção **Roles** com:

- os três papéis semeados, seu escopo e suas permissões;
- os dois fatos que o código **não** garante — titular único e conjunto fechado — com a instrução de auditar `user_roles` em vez de assumir um installation owner;
- `db/seeds/rbac.rb` como fonte autoritativa única.

Registra também que `Role::ADMIN_ROLE_KEYS` **não** é o modelo de papéis: é allowlist de bypass administrativo, mora em `evo-ai-crm-community/app/models/role.rb:44` (não no auth), vale `%w[super_admin account_owner administrator admin]` — nomeia papéis legados que o seed nunca cria — e as três cópias (auth `account_controller.rb:14`, CRM, front `src/constants/roles.ts`) divergem entre si.

Entrada no `CHANGELOG.md` sob `[Unreleased]`.

**PR irmão:** [evo-ai-crm-community #277](https://github.com/evolution-foundation/evo-ai-crm-community/pull/277) — a mesma frase falsa existia no README do repo do serviço.

Doc — sem teste.
